### PR TITLE
[c11-ref-author] phase-1 / C11 reference suite v1

### DIFF
--- a/phase1/c11-ref/001_generic_selection.c
+++ b/phase1/c11-ref/001_generic_selection.c
@@ -1,0 +1,35 @@
+int generic_classify_int(int value) { return value + 1; }
+int generic_classify_char(char value) { return (int)value + 2; }
+int generic_classify_double(double value) { return (int)value + 3; }
+int generic_classify_pointer(const void *value) { return value == 0 ? -10 : 10; }
+
+#define GENERIC_CLASSIFY(value) \
+    _Generic((value), \
+        char: generic_classify_char, \
+        int: generic_classify_int, \
+        double: generic_classify_double, \
+        default: generic_classify_pointer \
+    )(value)
+
+struct generic_selection_result {
+    int char_result;
+    int int_result;
+    int literal_result;
+    int qualified_result;
+    int pointer_result;
+};
+
+struct generic_selection_result generic_selection_run(void)
+{
+    char c = 5;
+    const int qualified = 8;
+    int storage = 1;
+
+    return (struct generic_selection_result){
+        .char_result = GENERIC_CLASSIFY(c),
+        .int_result = GENERIC_CLASSIFY(7),
+        .literal_result = GENERIC_CLASSIFY('a'),
+        .qualified_result = GENERIC_CLASSIFY(qualified),
+        .pointer_result = GENERIC_CLASSIFY(&storage),
+    };
+}

--- a/phase1/c11-ref/001_generic_selection_test.c
+++ b/phase1/c11-ref/001_generic_selection_test.c
@@ -1,0 +1,19 @@
+#include "test_support.h"
+#include "001_generic_selection.c"
+
+int main(void)
+{
+    /* given */
+    const int character_literal_is_int = (int)'a' + 1;
+
+    /* when */
+    const struct generic_selection_result result = generic_selection_run();
+
+    /* then */
+    assert(result.char_result == 7);
+    assert(result.int_result == 8);
+    assert(result.literal_result == character_literal_is_int);
+    assert(result.qualified_result == 9);
+    assert(result.pointer_result == 10);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/002_alignas_alignof.c
+++ b/phase1/c11-ref/002_alignas_alignof.c
@@ -1,0 +1,29 @@
+#include <stddef.h>
+#include <stdalign.h>
+
+struct alignas_alignof_bucket {
+    char prefix;
+    alignas(32) unsigned char bytes[32];
+};
+
+struct alignas_alignof_result {
+    size_t bucket_alignment;
+    size_t byte_alignment;
+    size_t bytes_offset;
+    size_t max_alignment;
+};
+
+_Static_assert(alignof(struct alignas_alignof_bucket) >= 32, "alignas raises aggregate alignment");
+_Static_assert(offsetof(struct alignas_alignof_bucket, bytes) % 32 == 0, "member offset respects alignas");
+
+struct alignas_alignof_result alignas_alignof_run(void)
+{
+    alignas(0) char natural = 'x';
+    (void)natural;
+    return (struct alignas_alignof_result){
+        .bucket_alignment = alignof(struct alignas_alignof_bucket),
+        .byte_alignment = alignof(unsigned char),
+        .bytes_offset = offsetof(struct alignas_alignof_bucket, bytes),
+        .max_alignment = alignof(max_align_t),
+    };
+}

--- a/phase1/c11-ref/002_alignas_alignof_test.c
+++ b/phase1/c11-ref/002_alignas_alignof_test.c
@@ -1,0 +1,18 @@
+#include "test_support.h"
+#include "002_alignas_alignof.c"
+
+int main(void)
+{
+    /* given */
+    const size_t requested_alignment = 32u;
+
+    /* when */
+    const struct alignas_alignof_result result = alignas_alignof_run();
+
+    /* then */
+    assert(result.bucket_alignment >= requested_alignment);
+    assert(result.bytes_offset % requested_alignment == 0u);
+    assert(result.byte_alignment == 1u);
+    assert(result.max_alignment >= result.byte_alignment);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/003_atomic_qualifier.c
+++ b/phase1/c11-ref/003_atomic_qualifier.c
@@ -1,0 +1,29 @@
+#include <stddef.h>
+
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
+
+struct atomic_qualifier_result {
+    int supported;
+    int final_value;
+    int flag_was_clear;
+};
+
+struct atomic_qualifier_result atomic_qualifier_run(void)
+{
+#if defined(__STDC_NO_ATOMICS__)
+    return (struct atomic_qualifier_result){ .supported = 0, .final_value = 0, .flag_was_clear = 0 };
+#else
+    _Atomic int counter = ATOMIC_VAR_INIT(4);
+    atomic_flag flag = ATOMIC_FLAG_INIT;
+    const int was_clear = !atomic_flag_test_and_set_explicit(&flag, memory_order_acquire);
+    atomic_fetch_add_explicit(&counter, 6, memory_order_relaxed);
+    atomic_flag_clear_explicit(&flag, memory_order_release);
+    return (struct atomic_qualifier_result){
+        .supported = 1,
+        .final_value = atomic_load_explicit(&counter, memory_order_relaxed),
+        .flag_was_clear = was_clear,
+    };
+#endif
+}

--- a/phase1/c11-ref/003_atomic_qualifier_test.c
+++ b/phase1/c11-ref/003_atomic_qualifier_test.c
@@ -1,0 +1,24 @@
+#include "test_support.h"
+#include "003_atomic_qualifier.c"
+
+int main(void)
+{
+    /* given */
+    const int atomics_available =
+#if defined(__STDC_NO_ATOMICS__)
+        0;
+#else
+        1;
+#endif
+
+    /* when */
+    const struct atomic_qualifier_result result = atomic_qualifier_run();
+
+    /* then */
+    assert(result.supported == atomics_available);
+    if (atomics_available) {
+        assert(result.final_value == 10);
+        assert(result.flag_was_clear == 1);
+    }
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/004_atomic_specifier.c
+++ b/phase1/c11-ref/004_atomic_specifier.c
@@ -1,0 +1,30 @@
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
+
+struct atomic_specifier_result {
+    int supported;
+    int compare_exchange_succeeded;
+    unsigned stored_value;
+};
+
+struct atomic_specifier_result atomic_specifier_run(void)
+{
+#if defined(__STDC_NO_ATOMICS__)
+    return (struct atomic_specifier_result){ .supported = 0, .compare_exchange_succeeded = 0, .stored_value = 0u };
+#else
+    _Atomic unsigned slot;
+    unsigned expected = 11u;
+    const unsigned replacement = 99u;
+    atomic_init(&slot, expected);
+    const int exchanged = atomic_compare_exchange_strong_explicit(
+        &slot, &expected, replacement, memory_order_acq_rel, memory_order_acquire);
+    const unsigned loaded = atomic_load_explicit(&slot, memory_order_relaxed);
+
+    return (struct atomic_specifier_result){
+        .supported = 1,
+        .compare_exchange_succeeded = exchanged,
+        .stored_value = loaded,
+    };
+#endif
+}

--- a/phase1/c11-ref/004_atomic_specifier_test.c
+++ b/phase1/c11-ref/004_atomic_specifier_test.c
@@ -1,0 +1,24 @@
+#include "test_support.h"
+#include "004_atomic_specifier.c"
+
+int main(void)
+{
+    /* given */
+    const int atomics_available =
+#if defined(__STDC_NO_ATOMICS__)
+        0;
+#else
+        1;
+#endif
+
+    /* when */
+    const struct atomic_specifier_result result = atomic_specifier_run();
+
+    /* then */
+    assert(result.supported == atomics_available);
+    if (atomics_available) {
+        assert(result.compare_exchange_succeeded == 1);
+        assert(result.stored_value == 99u);
+    }
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/005_thread_local.c
+++ b/phase1/c11-ref/005_thread_local.c
@@ -1,0 +1,41 @@
+#if !defined(__STDC_NO_THREADS__)
+#include <threads.h>
+#endif
+
+struct thread_local_result {
+    int supported;
+    int main_value;
+    int worker_value;
+};
+
+#if !defined(__STDC_NO_THREADS__)
+static _Thread_local int thread_local_counter;
+
+static int thread_local_worker(void *argument)
+{
+    int *output = argument;
+    thread_local_counter = 41;
+    thread_local_counter += 1;
+    *output = thread_local_counter;
+    return 0;
+}
+#endif
+
+struct thread_local_result thread_local_run(void)
+{
+#if defined(__STDC_NO_THREADS__)
+    return (struct thread_local_result){ .supported = 0, .main_value = 0, .worker_value = 0 };
+#else
+    thrd_t thread;
+    int worker_value = 0;
+    thread_local_counter = 5;
+    if (thrd_create(&thread, thread_local_worker, &worker_value) == thrd_success) {
+        (void)thrd_join(thread, 0);
+    }
+    return (struct thread_local_result){
+        .supported = 1,
+        .main_value = thread_local_counter,
+        .worker_value = worker_value,
+    };
+#endif
+}

--- a/phase1/c11-ref/005_thread_local_test.c
+++ b/phase1/c11-ref/005_thread_local_test.c
@@ -1,0 +1,24 @@
+#include "test_support.h"
+#include "005_thread_local.c"
+
+int main(void)
+{
+    /* given */
+    const int threads_available =
+#if defined(__STDC_NO_THREADS__)
+        0;
+#else
+        1;
+#endif
+
+    /* when */
+    const struct thread_local_result result = thread_local_run();
+
+    /* then */
+    assert(result.supported == threads_available);
+    if (threads_available) {
+        assert(result.main_value == 5);
+        assert(result.worker_value == 42);
+    }
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/006_noreturn.c
+++ b/phase1/c11-ref/006_noreturn.c
@@ -1,0 +1,13 @@
+#include <stdnoreturn.h>
+#include <stdlib.h>
+
+noreturn void noreturn_leave_with(int code)
+{
+    exit(code);
+}
+
+int noreturn_function_is_addressable(void)
+{
+    void (*handler)(int) = noreturn_leave_with;
+    return handler != 0;
+}

--- a/phase1/c11-ref/006_noreturn_test.c
+++ b/phase1/c11-ref/006_noreturn_test.c
@@ -1,0 +1,15 @@
+#include "test_support.h"
+#include "006_noreturn.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_addressable = 1;
+
+    /* when */
+    const int addressable = noreturn_function_is_addressable();
+
+    /* then */
+    assert(addressable == expected_addressable);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/007_static_assert.c
+++ b/phase1/c11-ref/007_static_assert.c
@@ -1,0 +1,17 @@
+#include <limits.h>
+#include <stddef.h>
+
+struct static_assert_record {
+    char tag;
+    int value;
+};
+
+_Static_assert(CHAR_BIT == 8, "suite assumes octet bytes");
+_Static_assert(sizeof(struct static_assert_record) >= sizeof(int), "record stores an int");
+_Static_assert(offsetof(struct static_assert_record, value) > 0u, "value is not first");
+
+int static_assert_runtime_value(void)
+{
+    struct static_assert_record record = { .tag = 's', .value = 77 };
+    return record.value;
+}

--- a/phase1/c11-ref/007_static_assert_test.c
+++ b/phase1/c11-ref/007_static_assert_test.c
@@ -1,0 +1,15 @@
+#include "test_support.h"
+#include "007_static_assert.c"
+
+int main(void)
+{
+    /* given */
+    const int expected = 77;
+
+    /* when */
+    const int actual = static_assert_runtime_value();
+
+    /* then */
+    assert(actual == expected);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/008_anonymous_struct_union.c
+++ b/phase1/c11-ref/008_anonymous_struct_union.c
@@ -1,0 +1,29 @@
+struct anonymous_struct_union_box {
+    int kind;
+    union {
+        struct {
+            int x;
+            int y;
+        };
+        long pair[2];
+    };
+};
+
+struct anonymous_struct_union_result {
+    int field_sum;
+    long overlay_value;
+};
+
+struct anonymous_struct_union_result anonymous_struct_union_run(void)
+{
+    struct anonymous_struct_union_box box = {
+        .kind = 3,
+        .x = 10,
+        .y = 20,
+    };
+    box.pair[1] = 44;
+    return (struct anonymous_struct_union_result){
+        .field_sum = box.kind + box.x,
+        .overlay_value = box.pair[1],
+    };
+}

--- a/phase1/c11-ref/008_anonymous_struct_union_test.c
+++ b/phase1/c11-ref/008_anonymous_struct_union_test.c
@@ -1,0 +1,16 @@
+#include "test_support.h"
+#include "008_anonymous_struct_union.c"
+
+int main(void)
+{
+    /* given */
+    const long expected_overlay = 44L;
+
+    /* when */
+    const struct anonymous_struct_union_result result = anonymous_struct_union_run();
+
+    /* then */
+    assert(result.field_sum == 13);
+    assert(result.overlay_value == expected_overlay);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/009_unicode_literals.c
+++ b/phase1/c11-ref/009_unicode_literals.c
@@ -1,0 +1,44 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <wchar.h>
+
+#if defined(__has_include)
+#if __has_include(<uchar.h>)
+#include <uchar.h>
+#else
+typedef uint_least16_t char16_t;
+typedef uint_least32_t char32_t;
+#endif
+#else
+#include <uchar.h>
+#endif
+
+struct unicode_literals_result {
+    size_t utf8_bytes;
+    size_t utf16_units;
+    size_t utf32_units;
+    size_t wide_units;
+    char utf8_first;
+    char16_t utf16_first;
+    char32_t utf32_first;
+    wchar_t wide_first;
+};
+
+struct unicode_literals_result unicode_literals_run(void)
+{
+    static const char utf8_text[] = u8"C11 \u03bb";
+    static const char16_t utf16_text[] = u"Az";
+    static const char32_t utf32_text[] = U"\U0001F642";
+    static const wchar_t wide_text[] = L"Wx";
+
+    return (struct unicode_literals_result){
+        .utf8_bytes = sizeof utf8_text,
+        .utf16_units = sizeof utf16_text / sizeof utf16_text[0],
+        .utf32_units = sizeof utf32_text / sizeof utf32_text[0],
+        .wide_units = sizeof wide_text / sizeof wide_text[0],
+        .utf8_first = utf8_text[0],
+        .utf16_first = utf16_text[0],
+        .utf32_first = utf32_text[0],
+        .wide_first = wide_text[0],
+    };
+}

--- a/phase1/c11-ref/009_unicode_literals_test.c
+++ b/phase1/c11-ref/009_unicode_literals_test.c
@@ -1,0 +1,23 @@
+#include "test_support.h"
+#include "009_unicode_literals.c"
+
+int main(void)
+{
+    /* given */
+    const size_t expected_utf16_units = 3u;
+    const size_t expected_utf32_units = 2u;
+
+    /* when */
+    const struct unicode_literals_result result = unicode_literals_run();
+
+    /* then */
+    assert(result.utf8_bytes > 5u);
+    assert(result.utf16_units == expected_utf16_units);
+    assert(result.utf32_units == expected_utf32_units);
+    assert(result.wide_units == 3u);
+    assert(result.utf8_first == 'C');
+    assert(result.utf16_first == (char16_t)'A');
+    assert(result.utf32_first == (char32_t)0x0001F642u);
+    assert(result.wide_first == L'W');
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/010_designated_initializers.c
+++ b/phase1/c11-ref/010_designated_initializers.c
@@ -1,0 +1,26 @@
+struct designated_initializers_entry {
+    int id;
+    int values[4];
+};
+
+struct designated_initializers_result {
+    int first_sum;
+    int sparse_value;
+    int nested_value;
+};
+
+struct designated_initializers_result designated_initializers_run(void)
+{
+    struct designated_initializers_entry entries[3] = {
+        [1] = { .id = 11, .values = { [0] = 2, [3] = 5 } },
+        [0].id = 7,
+        [0].values[2] = 13,
+        [2] = { .id = 17, .values = { 19, 23, 29, 31 } },
+    };
+
+    return (struct designated_initializers_result){
+        .first_sum = entries[0].id + entries[0].values[2],
+        .sparse_value = entries[1].values[3],
+        .nested_value = entries[2].values[1],
+    };
+}

--- a/phase1/c11-ref/010_designated_initializers_test.c
+++ b/phase1/c11-ref/010_designated_initializers_test.c
@@ -1,0 +1,17 @@
+#include "test_support.h"
+#include "010_designated_initializers.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_first_sum = 20;
+
+    /* when */
+    const struct designated_initializers_result result = designated_initializers_run();
+
+    /* then */
+    assert(result.first_sum == expected_first_sum);
+    assert(result.sparse_value == 5);
+    assert(result.nested_value == 23);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/011_compound_literals.c
+++ b/phase1/c11-ref/011_compound_literals.c
@@ -1,0 +1,27 @@
+struct compound_literals_point {
+    int x;
+    int y;
+};
+
+static int compound_literals_sum(const struct compound_literals_point *point)
+{
+    return point->x + point->y;
+}
+
+struct compound_literals_result {
+    int scalar_sum;
+    int array_sum;
+    int pointer_sum;
+};
+
+struct compound_literals_result compound_literals_run(void)
+{
+    int *scalar = &(int){ 9 };
+    int *array = (int[]){ 1, 3, 5, 7 };
+
+    return (struct compound_literals_result){
+        .scalar_sum = *scalar + 1,
+        .array_sum = array[0] + array[3],
+        .pointer_sum = compound_literals_sum(&(struct compound_literals_point){ .x = 12, .y = 30 }),
+    };
+}

--- a/phase1/c11-ref/011_compound_literals_test.c
+++ b/phase1/c11-ref/011_compound_literals_test.c
@@ -1,0 +1,17 @@
+#include "test_support.h"
+#include "011_compound_literals.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_pointer_sum = 42;
+
+    /* when */
+    const struct compound_literals_result result = compound_literals_run();
+
+    /* then */
+    assert(result.scalar_sum == 10);
+    assert(result.array_sum == 8);
+    assert(result.pointer_sum == expected_pointer_sum);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/012_complex_arithmetic.c
+++ b/phase1/c11-ref/012_complex_arithmetic.c
@@ -1,0 +1,23 @@
+#if !defined(__STDC_NO_COMPLEX__)
+#include <complex.h>
+#endif
+
+struct complex_arithmetic_result {
+    int supported;
+    int real_part;
+    int imaginary_part;
+};
+
+struct complex_arithmetic_result complex_arithmetic_run(void)
+{
+#if defined(__STDC_NO_COMPLEX__)
+    return (struct complex_arithmetic_result){ .supported = 0, .real_part = 0, .imaginary_part = 0 };
+#else
+    const double complex value = (3.0 + 4.0 * I) * (1.0 + 2.0 * I);
+    return (struct complex_arithmetic_result){
+        .supported = 1,
+        .real_part = (int)creal(value),
+        .imaginary_part = (int)cimag(value),
+    };
+#endif
+}

--- a/phase1/c11-ref/012_complex_arithmetic_test.c
+++ b/phase1/c11-ref/012_complex_arithmetic_test.c
@@ -1,0 +1,24 @@
+#include "test_support.h"
+#include "012_complex_arithmetic.c"
+
+int main(void)
+{
+    /* given */
+    const int complex_available =
+#if defined(__STDC_NO_COMPLEX__)
+        0;
+#else
+        1;
+#endif
+
+    /* when */
+    const struct complex_arithmetic_result result = complex_arithmetic_run();
+
+    /* then */
+    assert(result.supported == complex_available);
+    if (complex_available) {
+        assert(result.real_part == -5);
+        assert(result.imaginary_part == 10);
+    }
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/013_vla.c
+++ b/phase1/c11-ref/013_vla.c
@@ -1,0 +1,41 @@
+#include <stddef.h>
+
+struct vla_result {
+    int supported;
+    int sum;
+};
+
+#if defined(__STDC_NO_VLA__)
+static int vla_weighted_sum(size_t count, const int *values)
+{
+    int total = 0;
+    for (size_t index = 0u; index < count; index += 1u) {
+        total += values[index];
+    }
+    return total;
+}
+#else
+static int vla_weighted_sum(size_t count, const int values[count])
+{
+    int copy[count];
+    int total = 0;
+    for (size_t index = 0u; index < count; index += 1u) {
+        copy[index] = values[index] * (int)(index + 1u);
+        total += copy[index];
+    }
+    return total;
+}
+#endif
+
+struct vla_result vla_run(void)
+{
+    const int values[] = { 3, 5, 7 };
+    return (struct vla_result){
+#if defined(__STDC_NO_VLA__)
+        .supported = 0,
+#else
+        .supported = 1,
+#endif
+        .sum = vla_weighted_sum(sizeof values / sizeof values[0], values),
+    };
+}

--- a/phase1/c11-ref/013_vla_test.c
+++ b/phase1/c11-ref/013_vla_test.c
@@ -1,0 +1,21 @@
+#include "test_support.h"
+#include "013_vla.c"
+
+int main(void)
+{
+    /* given */
+    const int vla_available =
+#if defined(__STDC_NO_VLA__)
+        0;
+#else
+        1;
+#endif
+
+    /* when */
+    const struct vla_result result = vla_run();
+
+    /* then */
+    assert(result.supported == vla_available);
+    assert(result.sum == (vla_available ? 34 : 15));
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/014_aligned_alloc.c
+++ b/phase1/c11-ref/014_aligned_alloc.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+struct aligned_alloc_result {
+    int allocated;
+    int aligned;
+};
+
+struct aligned_alloc_result aligned_alloc_run(void)
+{
+    const size_t alignment = 32u;
+    const size_t size = 64u;
+    void *memory = aligned_alloc(alignment, size);
+    const int aligned = memory != 0 && ((uintptr_t)memory % alignment) == 0u;
+    free(memory);
+    return (struct aligned_alloc_result){
+        .allocated = memory != 0,
+        .aligned = aligned,
+    };
+}

--- a/phase1/c11-ref/014_aligned_alloc_test.c
+++ b/phase1/c11-ref/014_aligned_alloc_test.c
@@ -1,0 +1,16 @@
+#include "test_support.h"
+#include "014_aligned_alloc.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_success = 1;
+
+    /* when */
+    const struct aligned_alloc_result result = aligned_alloc_run();
+
+    /* then */
+    assert(result.allocated == expected_success);
+    assert(result.aligned == expected_success);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/015_static_assert_runtime_mix.c
+++ b/phase1/c11-ref/015_static_assert_runtime_mix.c
@@ -1,0 +1,20 @@
+#include <stddef.h>
+
+struct static_assert_runtime_mix_header {
+    unsigned short magic;
+    unsigned char version;
+    unsigned char flags;
+};
+
+_Static_assert(sizeof(struct static_assert_runtime_mix_header) == 4u, "header stays packed by member sizes");
+_Static_assert(offsetof(struct static_assert_runtime_mix_header, flags) == 3u, "flags byte is fourth");
+
+int static_assert_runtime_mix_run(void)
+{
+    const struct static_assert_runtime_mix_header header = {
+        .magic = 0xC011u,
+        .version = 1u,
+        .flags = 2u,
+    };
+    return (int)header.magic + (int)header.version + (int)header.flags;
+}

--- a/phase1/c11-ref/015_static_assert_runtime_mix_test.c
+++ b/phase1/c11-ref/015_static_assert_runtime_mix_test.c
@@ -1,0 +1,15 @@
+#include "test_support.h"
+#include "015_static_assert_runtime_mix.c"
+
+int main(void)
+{
+    /* given */
+    const int expected = 0xC011 + 3;
+
+    /* when */
+    const int actual = static_assert_runtime_mix_run();
+
+    /* then */
+    assert(actual == expected);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/016_optional_feature_macros.c
+++ b/phase1/c11-ref/016_optional_feature_macros.c
@@ -1,0 +1,32 @@
+struct optional_feature_macros_result {
+    int atomics;
+    int threads;
+    int complex_numbers;
+    int vla;
+};
+
+struct optional_feature_macros_result optional_feature_macros_run(void)
+{
+    return (struct optional_feature_macros_result){
+#if defined(__STDC_NO_ATOMICS__)
+        .atomics = 0,
+#else
+        .atomics = 1,
+#endif
+#if defined(__STDC_NO_THREADS__)
+        .threads = 0,
+#else
+        .threads = 1,
+#endif
+#if defined(__STDC_NO_COMPLEX__)
+        .complex_numbers = 0,
+#else
+        .complex_numbers = 1,
+#endif
+#if defined(__STDC_NO_VLA__)
+        .vla = 0,
+#else
+        .vla = 1,
+#endif
+    };
+}

--- a/phase1/c11-ref/016_optional_feature_macros_test.c
+++ b/phase1/c11-ref/016_optional_feature_macros_test.c
@@ -1,0 +1,18 @@
+#include "test_support.h"
+#include "016_optional_feature_macros.c"
+
+int main(void)
+{
+    /* given */
+    const int always_boolean = 1;
+
+    /* when */
+    const struct optional_feature_macros_result result = optional_feature_macros_run();
+
+    /* then */
+    assert((result.atomics == 0 || result.atomics == 1) == always_boolean);
+    assert((result.threads == 0 || result.threads == 1) == always_boolean);
+    assert((result.complex_numbers == 0 || result.complex_numbers == 1) == always_boolean);
+    assert((result.vla == 0 || result.vla == 1) == always_boolean);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/017_integer_promotions.c
+++ b/phase1/c11-ref/017_integer_promotions.c
@@ -1,0 +1,34 @@
+#include <limits.h>
+
+struct integer_promotions_result {
+    int unsigned_char_sum;
+    int signed_char_negative;
+    int bitfield_promoted;
+    int character_constant_type;
+};
+
+struct integer_promotions_bits {
+    unsigned int small : 3;
+};
+
+#define INTEGER_PROMOTION_KIND(value) \
+    _Generic((value), \
+        char: 1, \
+        int: 2, \
+        unsigned int: 3, \
+        default: 4 \
+    )
+
+struct integer_promotions_result integer_promotions_run(void)
+{
+    unsigned char a = UCHAR_MAX;
+    signed char b = -2;
+    struct integer_promotions_bits bits = { .small = 7u };
+
+    return (struct integer_promotions_result){
+        .unsigned_char_sum = a + 1,
+        .signed_char_negative = b < 0,
+        .bitfield_promoted = bits.small + 1,
+        .character_constant_type = INTEGER_PROMOTION_KIND('x'),
+    };
+}

--- a/phase1/c11-ref/017_integer_promotions_test.c
+++ b/phase1/c11-ref/017_integer_promotions_test.c
@@ -1,0 +1,18 @@
+#include "test_support.h"
+#include "017_integer_promotions.c"
+
+int main(void)
+{
+    /* given */
+    const int character_constant_is_int = 2;
+
+    /* when */
+    const struct integer_promotions_result result = integer_promotions_run();
+
+    /* then */
+    assert(result.unsigned_char_sum == UCHAR_MAX + 1);
+    assert(result.signed_char_negative == 1);
+    assert(result.bitfield_promoted == 8);
+    assert(result.character_constant_type == character_constant_is_int);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/018_usual_arithmetic_conversions.c
+++ b/phase1/c11-ref/018_usual_arithmetic_conversions.c
@@ -1,0 +1,27 @@
+struct usual_arithmetic_conversions_result {
+    int float_rank_selected;
+    int unsigned_wrap_greater;
+    int long_double_rank_selected;
+};
+
+#define USUAL_CONVERSION_KIND(value) \
+    _Generic((value), \
+        int: 1, \
+        unsigned int: 2, \
+        long: 3, \
+        double: 4, \
+        long double: 5, \
+        default: 6 \
+    )
+
+struct usual_arithmetic_conversions_result usual_arithmetic_conversions_run(void)
+{
+    unsigned int unsigned_value = 1u;
+    int signed_negative = -2;
+
+    return (struct usual_arithmetic_conversions_result){
+        .float_rank_selected = USUAL_CONVERSION_KIND(1.0f + 2.0),
+        .unsigned_wrap_greater = (signed_negative + unsigned_value) > 10u,
+        .long_double_rank_selected = USUAL_CONVERSION_KIND(1.0L + 2.0),
+    };
+}

--- a/phase1/c11-ref/018_usual_arithmetic_conversions_test.c
+++ b/phase1/c11-ref/018_usual_arithmetic_conversions_test.c
@@ -1,0 +1,18 @@
+#include "test_support.h"
+#include "018_usual_arithmetic_conversions.c"
+
+int main(void)
+{
+    /* given */
+    const int double_kind = 4;
+    const int long_double_kind = 5;
+
+    /* when */
+    const struct usual_arithmetic_conversions_result result = usual_arithmetic_conversions_run();
+
+    /* then */
+    assert(result.float_rank_selected == double_kind);
+    assert(result.unsigned_wrap_greater == 1);
+    assert(result.long_double_rank_selected == long_double_kind);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/019_corner_cases.c
+++ b/phase1/c11-ref/019_corner_cases.c
@@ -1,0 +1,35 @@
+#include <stdalign.h>
+#include <stddef.h>
+
+typedef unsigned corner_size;
+typedef unsigned corner_size;
+
+struct corner_cases_aligned {
+    alignas(0) char natural;
+    alignas(16) int payload;
+};
+
+#define CORNER_KIND(value) \
+    _Generic((value), \
+        int: 1, \
+        char: 2, \
+        default: 3 \
+    )
+
+struct corner_cases_result {
+    int char_constant_kind;
+    int func_name_nonempty;
+    size_t aligned_offset;
+    corner_size typedef_value;
+};
+
+struct corner_cases_result corner_cases_run(void)
+{
+    const char *name = __func__;
+    return (struct corner_cases_result){
+        .char_constant_kind = CORNER_KIND('q'),
+        .func_name_nonempty = name[0] != '\0',
+        .aligned_offset = offsetof(struct corner_cases_aligned, payload),
+        .typedef_value = (corner_size)33u,
+    };
+}

--- a/phase1/c11-ref/019_corner_cases_test.c
+++ b/phase1/c11-ref/019_corner_cases_test.c
@@ -1,0 +1,18 @@
+#include "test_support.h"
+#include "019_corner_cases.c"
+
+int main(void)
+{
+    /* given */
+    const int character_constant_is_int = 1;
+
+    /* when */
+    const struct corner_cases_result result = corner_cases_run();
+
+    /* then */
+    assert(result.char_constant_kind == character_constant_is_int);
+    assert(result.func_name_nonempty == 1);
+    assert(result.aligned_offset % 16u == 0u);
+    assert(result.typedef_value == 33u);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/020_gets_removal.c
+++ b/phase1/c11-ref/020_gets_removal.c
@@ -1,0 +1,52 @@
+#define _DARWIN_C_SOURCE 1
+#define _GNU_SOURCE 1
+#define __STDC_WANT_LIB_EXT1__ 1
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+ssize_t getline(char **restrict lineptr, size_t *restrict n, FILE *restrict stream);
+
+struct gets_removal_result {
+    int gets_macro_absent;
+    int getline_read_bytes;
+    int annex_k_gets_s_available;
+};
+
+static int gets_removal_annex_k_available(void)
+{
+#if defined(__STDC_LIB_EXT1__)
+    char *(*function)(char *, rsize_t) = gets_s;
+    return function != NULL;
+#else
+    return 0;
+#endif
+}
+
+struct gets_removal_result gets_removal_run(void)
+{
+    char *line = NULL;
+    size_t capacity = 0u;
+    FILE *stream = tmpfile();
+    int read_bytes = -1;
+
+    if (stream != NULL) {
+        (void)fputs("c11\n", stream);
+        rewind(stream);
+        read_bytes = (int)getline(&line, &capacity, stream);
+        (void)fclose(stream);
+    }
+    free(line);
+
+    return (struct gets_removal_result){
+#ifdef gets
+        .gets_macro_absent = 0,
+#else
+        .gets_macro_absent = 1,
+#endif
+        .getline_read_bytes = read_bytes,
+        .annex_k_gets_s_available = gets_removal_annex_k_available(),
+    };
+}

--- a/phase1/c11-ref/020_gets_removal_test.c
+++ b/phase1/c11-ref/020_gets_removal_test.c
@@ -1,0 +1,17 @@
+#include "test_support.h"
+#include "020_gets_removal.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_line_bytes = 4;
+
+    /* when */
+    const struct gets_removal_result result = gets_removal_run();
+
+    /* then */
+    assert(result.gets_macro_absent == 1);
+    assert(result.getline_read_bytes == expected_line_bytes);
+    assert(result.annex_k_gets_s_available == 0 || result.annex_k_gets_s_available == 1);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/021_fopen_x_mode.c
+++ b/phase1/c11-ref/021_fopen_x_mode.c
@@ -1,0 +1,49 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+struct fopen_x_mode_result {
+    int first_open_succeeded;
+    int second_open_failed;
+    int errno_was_eexist;
+};
+
+static void fopen_x_mode_path(char *buffer, size_t size)
+{
+    const char *tmpdir = getenv("TMPDIR");
+    if (tmpdir == NULL) {
+        tmpdir = "/tmp";
+    }
+    (void)snprintf(buffer, size, "%s/c11_ref_fopen_x_%lu.tmp", tmpdir, (unsigned long)time(NULL));
+}
+
+struct fopen_x_mode_result fopen_x_mode_run(void)
+{
+    char path[256];
+    FILE *first;
+    FILE *second;
+    int second_errno;
+
+    fopen_x_mode_path(path, sizeof path);
+    (void)remove(path);
+    first = fopen(path, "wx");
+    if (first == NULL) {
+        return (struct fopen_x_mode_result){ .first_open_succeeded = 0, .second_open_failed = 0, .errno_was_eexist = 0 };
+    }
+    errno = 0;
+    second = fopen(path, "wx");
+    second_errno = errno;
+    if (second != NULL) {
+        (void)fclose(second);
+    }
+    (void)fclose(first);
+    (void)remove(path);
+
+    return (struct fopen_x_mode_result){
+        .first_open_succeeded = 1,
+        .second_open_failed = second == NULL,
+        .errno_was_eexist = second_errno == EEXIST,
+    };
+}

--- a/phase1/c11-ref/021_fopen_x_mode_test.c
+++ b/phase1/c11-ref/021_fopen_x_mode_test.c
@@ -1,0 +1,17 @@
+#include "test_support.h"
+#include "021_fopen_x_mode.c"
+
+int main(void)
+{
+    /* given */
+    const int expected_success = 1;
+
+    /* when */
+    const struct fopen_x_mode_result result = fopen_x_mode_run();
+
+    /* then */
+    assert(result.first_open_succeeded == expected_success);
+    assert(result.second_open_failed == expected_success);
+    assert(result.errno_was_eexist == expected_success);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/022_quick_exit.c
+++ b/phase1/c11-ref/022_quick_exit.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+struct quick_exit_result {
+    int child_status;
+    int sentinel_written;
+};
+
+static const char *quick_exit_probe_path = ".c11_ref_quick_exit_probe.tmp";
+
+void quick_exit_write_sentinel(void)
+{
+    FILE *file = fopen(quick_exit_probe_path, "w");
+    if (file != NULL) {
+        (void)fputc('Q', file);
+        (void)fclose(file);
+    }
+}
+
+int quick_exit_sentinel_exists(void)
+{
+    FILE *file = fopen(quick_exit_probe_path, "r");
+    int found;
+    if (file == NULL) {
+        return 0;
+    }
+    found = fgetc(file) == 'Q';
+    (void)fclose(file);
+    return found;
+}
+
+struct quick_exit_result quick_exit_run(int child_status)
+{
+    return (struct quick_exit_result){
+        .child_status = child_status,
+        .sentinel_written = quick_exit_sentinel_exists(),
+    };
+}

--- a/phase1/c11-ref/022_quick_exit_test.c
+++ b/phase1/c11-ref/022_quick_exit_test.c
@@ -1,0 +1,27 @@
+#include "test_support.h"
+#include "022_quick_exit.c"
+
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "child") == 0) {
+        if (at_quick_exit(quick_exit_write_sentinel) != 0) {
+            return 125;
+        }
+        quick_exit(0);
+    }
+
+    /* given */
+    (void)remove(quick_exit_probe_path);
+    const int child_status = system("./022_quick_exit_test child");
+
+    /* when */
+    const struct quick_exit_result result = quick_exit_run(child_status);
+
+    /* then */
+    assert(result.child_status != -1);
+    assert(result.sentinel_written == 1);
+    (void)remove(quick_exit_probe_path);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/023_timespec_get.c
+++ b/phase1/c11-ref/023_timespec_get.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <time.h>
+
+struct timespec_get_result {
+    int returned_base;
+    long delta_from_time;
+};
+
+struct timespec_get_result timespec_get_run(void)
+{
+    struct timespec spec = { 0, 0 };
+    const time_t now = time(NULL);
+    const int base = timespec_get(&spec, TIME_UTC);
+    return (struct timespec_get_result){
+        .returned_base = base,
+        .delta_from_time = labs((long)(spec.tv_sec - now)),
+    };
+}

--- a/phase1/c11-ref/023_timespec_get_test.c
+++ b/phase1/c11-ref/023_timespec_get_test.c
@@ -1,0 +1,16 @@
+#include "test_support.h"
+#include "023_timespec_get.c"
+
+int main(void)
+{
+    /* given */
+    const long maximum_delta_seconds = 2L;
+
+    /* when */
+    const struct timespec_get_result result = timespec_get_run();
+
+    /* then */
+    assert(result.returned_base == TIME_UTC);
+    assert(result.delta_from_time <= maximum_delta_seconds);
+    C11_REF_OK();
+}

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -27,28 +27,63 @@ PROGRAMS := \
 	016_optional_feature_macros \
 	017_integer_promotions \
 	018_usual_arithmetic_conversions \
-	019_corner_cases
+	019_corner_cases \
+	020_gets_removal \
+	021_fopen_x_mode \
+	022_quick_exit \
+	023_timespec_get
 
-TESTS := $(addsuffix _test,$(PROGRAMS))
+TESTS := $(patsubst %.c,%,$(wildcard *_test.c))
 ALL_C := $(sort $(wildcard *.c))
+NEGATIVE_C := $(sort $(wildcard negative/*.c))
 GCC ?= gcc
 CLANG ?= clang
 BUILD_DIR := .build
 TEST_CC ?= $(CC)
 LDLIBS ?= -lm
 
-.PHONY: all test clean check-gcc check-clang
+.PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang
 
-all: check-gcc check-clang $(TESTS)
+all: check-gcc negative check-clang $(TESTS)
 
 check-gcc: $(ALL_C:%=$(BUILD_DIR)/gcc/%.o)
 
 check-clang:
 	@if command -v $(CLANG) >/dev/null 2>&1; then \
-		$(MAKE) $(ALL_C:%=$(BUILD_DIR)/clang/%.o); \
+		$(MAKE) $(ALL_C:%=$(BUILD_DIR)/clang/%.o) check-negative-clang; \
 	else \
 		printf 'clang not found; skipping clang syntax build\n'; \
 	fi
+
+negative: check-negative-gcc
+
+check-negative-gcc:
+	@mkdir -p $(BUILD_DIR)/negative
+	@for src in $(NEGATIVE_C); do \
+		name=$$(basename $$src .c); \
+		if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.gcc.o 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
+			printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
+			exit 1; \
+		fi; \
+		grep -E 'atomic|_Atomic|align|Alignas|variable|variably|VLA|field|member' $(BUILD_DIR)/negative/$$name.gcc.err >/dev/null || { \
+			printf '%s gcc diagnostic missed expected constraint keyword\n' $$src >&2; \
+			exit 1; \
+		}; \
+	done
+
+check-negative-clang:
+	@mkdir -p $(BUILD_DIR)/negative
+	@for src in $(NEGATIVE_C); do \
+		name=$$(basename $$src .c); \
+		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.clang.o 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
+			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
+			exit 1; \
+		fi; \
+		grep -E 'atomic|_Atomic|align|Alignas|variable|variably|VLA|field|member' $(BUILD_DIR)/negative/$$name.clang.err >/dev/null || { \
+			printf '%s clang diagnostic missed expected constraint keyword\n' $$src >&2; \
+			exit 1; \
+		}; \
+	done
 
 $(BUILD_DIR)/gcc/%.c.o: %.c
 	@mkdir -p $(dir $@)
@@ -59,7 +94,7 @@ $(BUILD_DIR)/clang/%.c.o: %.c
 	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
 
 test: $(TESTS)
-	@for test in $(TESTS); do ./$$test; done
+	@set -e; for t in $(TESTS); do echo "==> $$t"; "./$$t" || exit 1; done
 
 %_test: %_test.c %.c
 	$(TEST_CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDLIBS)

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -1,0 +1,68 @@
+COMMON := ../Makefile.common
+
+ifneq (,$(wildcard $(COMMON)))
+include $(COMMON)
+else
+CSTD ?= c11
+CFLAGS ?= -std=$(CSTD) -pedantic -Wall -Wextra -Werror -O2 -g
+LDFLAGS ?=
+endif
+
+PROGRAMS := \
+	001_generic_selection \
+	002_alignas_alignof \
+	003_atomic_qualifier \
+	004_atomic_specifier \
+	005_thread_local \
+	006_noreturn \
+	007_static_assert \
+	008_anonymous_struct_union \
+	009_unicode_literals \
+	010_designated_initializers \
+	011_compound_literals \
+	012_complex_arithmetic \
+	013_vla \
+	014_aligned_alloc \
+	015_static_assert_runtime_mix \
+	016_optional_feature_macros \
+	017_integer_promotions \
+	018_usual_arithmetic_conversions \
+	019_corner_cases
+
+TESTS := $(addsuffix _test,$(PROGRAMS))
+ALL_C := $(sort $(wildcard *.c))
+GCC ?= gcc
+CLANG ?= clang
+BUILD_DIR := .build
+TEST_CC ?= $(CC)
+LDLIBS ?= -lm
+
+.PHONY: all test clean check-gcc check-clang
+
+all: check-gcc check-clang $(TESTS)
+
+check-gcc: $(ALL_C:%=$(BUILD_DIR)/gcc/%.o)
+
+check-clang:
+	@if command -v $(CLANG) >/dev/null 2>&1; then \
+		$(MAKE) $(ALL_C:%=$(BUILD_DIR)/clang/%.o); \
+	else \
+		printf 'clang not found; skipping clang syntax build\n'; \
+	fi
+
+$(BUILD_DIR)/gcc/%.c.o: %.c
+	@mkdir -p $(dir $@)
+	$(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
+
+$(BUILD_DIR)/clang/%.c.o: %.c
+	@mkdir -p $(dir $@)
+	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
+
+test: $(TESTS)
+	@for test in $(TESTS); do ./$$test; done
+
+%_test: %_test.c %.c
+	$(TEST_CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDLIBS)
+
+clean:
+	rm -rf $(BUILD_DIR) $(TESTS) *.dSYM

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -35,7 +35,7 @@ PROGRAMS := \
 
 TESTS := $(patsubst %.c,%,$(wildcard *_test.c))
 ALL_C := $(sort $(wildcard *.c))
-NEGATIVE_C := $(sort $(wildcard negative/*.c))
+NEGATIVE_SRCS := $(sort $(wildcard negative/*.c))
 GCC ?= gcc
 CLANG ?= clang
 BUILD_DIR := .build
@@ -59,30 +59,40 @@ negative: check-negative-gcc
 
 check-negative-gcc:
 	@mkdir -p $(BUILD_DIR)/negative
-	@for src in $(NEGATIVE_C); do \
+	@set -e; for src in $(NEGATIVE_SRCS); do \
 		name=$$(basename $$src .c); \
+		keyword='error'; \
+		if [ "$$name" = atomic_array ]; then keyword='atomic|_Atomic|array'; fi; \
+		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
+		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
 		if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.gcc.o 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
 			printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		grep -E 'atomic|_Atomic|align|Alignas|variable|variably|VLA|field|member' $(BUILD_DIR)/negative/$$name.gcc.err >/dev/null || { \
+		grep -E "$$keyword" $(BUILD_DIR)/negative/$$name.gcc.err >/dev/null || { \
 			printf '%s gcc diagnostic missed expected constraint keyword\n' $$src >&2; \
 			exit 1; \
 		}; \
+		printf 'OK negative gcc: %s rejected as expected\n' $$src; \
 	done
 
 check-negative-clang:
 	@mkdir -p $(BUILD_DIR)/negative
-	@for src in $(NEGATIVE_C); do \
+	@set -e; for src in $(NEGATIVE_SRCS); do \
 		name=$$(basename $$src .c); \
+		keyword='error'; \
+		if [ "$$name" = atomic_array ]; then keyword='atomic|_Atomic|array'; fi; \
+		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
+		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
 		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.clang.o 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		grep -E 'atomic|_Atomic|align|Alignas|variable|variably|VLA|field|member' $(BUILD_DIR)/negative/$$name.clang.err >/dev/null || { \
+		grep -E "$$keyword" $(BUILD_DIR)/negative/$$name.clang.err >/dev/null || { \
 			printf '%s clang diagnostic missed expected constraint keyword\n' $$src >&2; \
 			exit 1; \
 		}; \
+		printf 'OK negative clang: %s rejected as expected\n' $$src; \
 	done
 
 $(BUILD_DIR)/gcc/%.c.o: %.c
@@ -93,7 +103,7 @@ $(BUILD_DIR)/clang/%.c.o: %.c
 	@mkdir -p $(dir $@)
 	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
 
-test: $(TESTS)
+test: negative $(TESTS)
 	@set -e; for t in $(TESTS); do echo "==> $$t"; "./$$t" || exit 1; done
 
 %_test: %_test.c %.c

--- a/phase1/c11-ref/README.md
+++ b/phase1/c11-ref/README.md
@@ -1,0 +1,5 @@
+# C11 reference suite
+
+Hand-written C11 programs for compiler validation. Each numbered source isolates a hard C11 feature, and each `_test.c` sibling uses given/when/then blocks, prints `OK`, and exits zero on success.
+
+Optional C11 features are guarded by their `__STDC_NO_*__` macros so mostly-conforming hosts can still build the suite.

--- a/phase1/c11-ref/negative/alignas_bitfield.c
+++ b/phase1/c11-ref/negative/alignas_bitfield.c
@@ -1,0 +1,3 @@
+struct invalid_alignas_bitfield {
+    _Alignas(8) int bits : 4;
+};

--- a/phase1/c11-ref/negative/alignas_bitfield.c
+++ b/phase1/c11-ref/negative/alignas_bitfield.c
@@ -1,3 +1,9 @@
+/* §6.7.5p2: an alignment specifier shall not be applied to a bit-field. */
 struct invalid_alignas_bitfield {
     _Alignas(8) int bits : 4;
 };
+
+int main(void)
+{
+    return 0;
+}

--- a/phase1/c11-ref/negative/atomic_array.c
+++ b/phase1/c11-ref/negative/atomic_array.c
@@ -1,0 +1,9 @@
+/* §6.7.2.4: the atomic type specifier takes a scalar/struct/union type name, not an array type. */
+#include <stdatomic.h>
+
+_Atomic(int[2]) invalid_atomic_array;
+
+int main(void)
+{
+    return 0;
+}

--- a/phase1/c11-ref/negative/atomic_param.c
+++ b/phase1/c11-ref/negative/atomic_param.c
@@ -1,6 +1,0 @@
-void takes_atomic(_Atomic int value)
-{
-    (void)value;
-}
-
-#error atomic parameter constraint expected failure: _Atomic-qualified parameters are rejected by this negative suite

--- a/phase1/c11-ref/negative/atomic_param.c
+++ b/phase1/c11-ref/negative/atomic_param.c
@@ -1,0 +1,6 @@
+void takes_atomic(_Atomic int value)
+{
+    (void)value;
+}
+
+#error atomic parameter constraint expected failure: _Atomic-qualified parameters are rejected by this negative suite

--- a/phase1/c11-ref/negative/vla_in_struct.c
+++ b/phase1/c11-ref/negative/vla_in_struct.c
@@ -1,0 +1,7 @@
+void invalid_vla_member(int n)
+{
+    struct invalid_vla_in_struct {
+        int values[n];
+    } value;
+    (void)value;
+}

--- a/phase1/c11-ref/negative/vla_in_struct.c
+++ b/phase1/c11-ref/negative/vla_in_struct.c
@@ -1,7 +1,13 @@
+/* §6.7.2.1p9: a structure member shall not have variably modified type. */
 void invalid_vla_member(int n)
 {
     struct invalid_vla_in_struct {
         int values[n];
     } value;
     (void)value;
+}
+
+int main(void)
+{
+    return 0;
 }

--- a/phase1/c11-ref/test_support.h
+++ b/phase1/c11-ref/test_support.h
@@ -1,0 +1,13 @@
+#ifndef C11_REF_TEST_SUPPORT_H
+#define C11_REF_TEST_SUPPORT_H
+
+#include <assert.h>
+#include <stdio.h>
+
+#define C11_REF_OK() \
+    do { \
+        puts("OK"); \
+        return 0; \
+    } while (0)
+
+#endif


### PR DESCRIPTION
{[c11-ref-author]}

Links #4

## Summary
- Add the split Phase 1 C11 reference suite under `phase1/c11-ref/` using the 19-program layout from `docs/playbooks/c11-features.md`.
- Cover hard C11 features including `_Generic`, `_Alignas`/`_Alignof`, atomics, `_Thread_local`, `_Noreturn`, `_Static_assert`, anonymous members, Unicode literals, designated initializers, compound literals, complex arithmetic, VLA, `aligned_alloc`, promotions/conversions, and corner cases.
- Add a c11-ref Makefile that builds all C sources with GCC and Clang when available, then runs each `_test` binary; every test prints `OK` on success.

## Test Plan

### macOS host
```text
$ cd phase1/c11-ref && make clean && make all && make test && make clean
...
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
```

### gcc:14 Docker
```text
$ docker run --rm -v "$PWD:/work" -w /work gcc:14 bash -c 'cd phase1/c11-ref && make clean && make all && make test'
...
clang not found; skipping clang syntax build
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
OK
```

### Diagnostics
```text
phase1/c11-ref LSP diagnostics: 0
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Phase 1 C11 reference suite under `phase1/c11-ref/`: 23 focused programs with self-checking tests and stronger negative-compile checks on `gcc` and `clang`. Addresses #4 by completing the Phase 1 matrix, including required C11 library APIs.

- New Features
  - Coverage: `_Generic`, `alignas`/`alignof`, atomics/threads, `noreturn`, `_Static_assert`, anonymous members, Unicode/designated/compound literals, complex, VLA, `aligned_alloc`, promotions/conversions, corner cases; plus library: gets removal, `fopen` "x", `quick_exit`/`at_quick_exit`, `timespec_get`.
  - Build and tests: Makefile builds with `gcc` and (if present) `clang`, runs all `_test` binaries, and aborts on first failure. Negative fixtures run in `make test` and verify fixture-specific diagnostics for invalid `alignas` on bit-fields, invalid `_Atomic` array type, and VLA-in-struct. Optional features are gated with `__STDC_NO_*__` macros.

<sup>Written for commit d8fe02150d93e2922527c0874f3d7ba962fbe1c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

