### PR TITLE
[Sisyphus] infra(ci): gate phase-2/3 jobs on file presence; codify PR-only policy

### DIFF
--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -12,8 +12,26 @@ on:
       - '.github/workflows/phase2-zig.yml'
 
 jobs:
+  guard:
+    name: phase-2 guard
+    runs-on: ubuntu-latest
+    outputs:
+      has_zig: ${{ steps.detect.outputs.has_zig }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        run: |
+          if [ -f phase2/build.zig ]; then
+            echo "has_zig=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_zig=false" >> "$GITHUB_OUTPUT"
+            echo "phase2/build.zig not present yet — phase-2 build/test skipped."
+          fi
+
   build-and-test:
     name: zcc build & test (${{ matrix.os }})
+    needs: guard
+    if: needs.guard.outputs.has_zig == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -26,14 +44,11 @@ jobs:
         with:
           version: 0.16.0
       - name: zig fmt --check
-        if: hashFiles('phase2/build.zig') != ''
         working-directory: phase2
         run: zig fmt --check src tests build.zig
       - name: zig build
-        if: hashFiles('phase2/build.zig') != ''
         working-directory: phase2
         run: zig build -Drelease-safe
       - name: zig build test
-        if: hashFiles('phase2/build.zig') != ''
         working-directory: phase2
         run: zig build test --summary all

--- a/.github/workflows/phase3-verify.yml
+++ b/.github/workflows/phase3-verify.yml
@@ -19,20 +19,27 @@ jobs:
     outputs:
       has_diff: ${{ steps.detect.outputs.has_diff }}
       has_cross: ${{ steps.detect.outputs.has_cross }}
+      has_zig: ${{ steps.detect.outputs.has_zig }}
     steps:
       - uses: actions/checkout@v4
       - id: detect
         run: |
           [ -f phase3/run-diff.sh ] && echo "has_diff=true" >> "$GITHUB_OUTPUT" || echo "has_diff=false" >> "$GITHUB_OUTPUT"
           [ -f phase3/run-cross-docker.sh ] && echo "has_cross=true" >> "$GITHUB_OUTPUT" || echo "has_cross=false" >> "$GITHUB_OUTPUT"
-          if [ ! -f phase3/run-diff.sh ] && [ ! -f phase3/run-cross-docker.sh ]; then
-            echo "phase3 verification scripts not present yet — phase-3 jobs skipped."
+          [ -f phase2/build.zig ] && echo "has_zig=true" >> "$GITHUB_OUTPUT" || echo "has_zig=false" >> "$GITHUB_OUTPUT"
+          missing=()
+          [ ! -f phase3/run-diff.sh ] && missing+=("phase3/run-diff.sh")
+          [ ! -f phase3/run-cross-docker.sh ] && missing+=("phase3/run-cross-docker.sh")
+          [ ! -f phase2/build.zig ] && missing+=("phase2/build.zig")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf 'phase-3 prerequisites missing — affected jobs will be skipped:\n'
+            printf '  - %s\n' "${missing[@]}"
           fi
 
   zcc-vs-gcc:
     name: zcc-vs-gcc differential (${{ matrix.os }})
     needs: guard
-    if: needs.guard.outputs.has_diff == 'true'
+    if: needs.guard.outputs.has_diff == 'true' && needs.guard.outputs.has_zig == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +62,7 @@ jobs:
   cross-compile-linux:
     name: zcc cross-compile (linux x86_64) under docker
     needs: guard
-    if: needs.guard.outputs.has_cross == 'true'
+    if: needs.guard.outputs.has_cross == 'true' && needs.guard.outputs.has_zig == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phase3-verify.yml
+++ b/.github/workflows/phase3-verify.yml
@@ -13,8 +13,26 @@ on:
       - '.github/workflows/phase3-verify.yml'
 
 jobs:
+  guard:
+    name: phase-3 guard
+    runs-on: ubuntu-latest
+    outputs:
+      has_diff: ${{ steps.detect.outputs.has_diff }}
+      has_cross: ${{ steps.detect.outputs.has_cross }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: detect
+        run: |
+          [ -f phase3/run-diff.sh ] && echo "has_diff=true" >> "$GITHUB_OUTPUT" || echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          [ -f phase3/run-cross-docker.sh ] && echo "has_cross=true" >> "$GITHUB_OUTPUT" || echo "has_cross=false" >> "$GITHUB_OUTPUT"
+          if [ ! -f phase3/run-diff.sh ] && [ ! -f phase3/run-cross-docker.sh ]; then
+            echo "phase3 verification scripts not present yet — phase-3 jobs skipped."
+          fi
+
   zcc-vs-gcc:
     name: zcc-vs-gcc differential (${{ matrix.os }})
+    needs: guard
+    if: needs.guard.outputs.has_diff == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -27,18 +45,17 @@ jobs:
         with:
           version: 0.16.0
       - name: Build zcc
-        if: hashFiles('phase2/build.zig') != ''
         working-directory: phase2
         run: zig build -Drelease-safe
       - name: Run differential tests (-O0)
-        if: hashFiles('phase3/run-diff.sh') != ''
         run: bash phase3/run-diff.sh -O0
       - name: Run differential tests (-O2)
-        if: hashFiles('phase3/run-diff.sh') != ''
         run: bash phase3/run-diff.sh -O2
 
   cross-compile-linux:
     name: zcc cross-compile (linux x86_64) under docker
+    needs: guard
+    if: needs.guard.outputs.has_cross == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,9 +64,7 @@ jobs:
         with:
           version: 0.16.0
       - name: Build zcc
-        if: hashFiles('phase2/build.zig') != ''
         working-directory: phase2
         run: zig build -Drelease-safe
       - name: Cross-compile sample to linux-x86_64 and run in docker
-        if: hashFiles('phase3/run-cross-docker.sh') != ''
         run: bash phase3/run-cross-docker.sh

--- a/docs/team/charter.md
+++ b/docs/team/charter.md
@@ -42,7 +42,9 @@ Nothing is compromised. Phase N+1 cannot begin until Phase N's success criteria 
 
 ## 3. Branching & PR rules
 
-- Master is protected by process. **No direct commits to master**.
+- Master is protected by **GitHub branch protection**. **No direct commits to master**, including by Sisyphus (the lead). Every change — even one-line CI tweaks — goes via PR.
+- Master may only contain commits whose CI is fully green at merge time.
+- Identity discipline: every commit, PR, comment, and review must be tagged `[your-name]` / `{[your-name]} ...`. Use **your real role name**, never `[Sisyphus]` unless you literally are the lead.
 - Each work item lives in a feature branch named `phase{N}/{topic}/{short-desc}`, e.g. `phase1/doom/sdl-loop`.
 - We use **git worktrees** for parallel work. See `docs/playbooks/git-worktrees.md`.
 - PRs **must**:


### PR DESCRIPTION
## Summary

{[Sisyphus]} Fixes the master CI that was red after `b47b1f1`. Codifies the no-direct-master-push policy and the `[role-name]` identity rule.

## Changes

- `.github/workflows/phase2-zig.yml`: split into a tiny `guard` job that detects `phase2/build.zig`, plus a real `build-and-test` job that only runs when the guard passes. Stops the workflow from failing when no Zig project exists yet.
- `.github/workflows/phase3-verify.yml`: same pattern for `phase3/run-diff.sh` and `run-cross-docker.sh`.
- `docs/team/charter.md`: codifies `no direct master push, even by Sisyphus`, `master only contains CI-passing commits`, and the identity rule (`tag with your real role name, never [Sisyphus]`).

## Why CI was failing on master

The `setup-zig` action couldn't reach any Zig CDN (404/503 from every mirror): see https://github.com/code-yeongyu/c11-compiler-zig-omo/actions/runs/24974515100. Even with `if: hashFiles(...) != ''` on the build steps, the **`Install Zig`** step was unconditional and always executed before the guards. Gating the entire job on a guard removes that dependency until phase-2 actually exists.

## Test Plan

- This branch's `phase-2-zig` workflow run will show the `guard` job as success and the `build-and-test` job as **skipped** — ✅.
- Same for `phase-3-verify`'s `guard` + `zcc-vs-gcc` + `cross-compile-linux`.
- `phase-1-c` workflow is unaffected (still runs the `c11-reference-native`, `http2-server-native`, `doom-port`, `cross-compile-linux-in-docker` jobs guarded by `hashFiles`).

## Reviewers

- {[reviewer-ultrabrain]} please review for correctness (job-level guard pattern, race-free, no leakage).
- {[ci-engineer]} (acting as `reviewer-quality`) please review for CI/Make hygiene.
- {[verifier-deep]} please run the matrix and post `verifier-deep: PASS`.
- {[qa-tester]} please attach a short evidence comment confirming the workflows show as green/skipped on this branch.

Closes nothing — this is meta-infrastructure tracked under issue #1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Phase 2/3 CI jobs on required files so they skip cleanly until those files exist, avoiding unnecessary Zig installs and preventing red CI on `master`. Phase 3 jobs now require both their scripts and `phase2/build.zig`; the team charter now enforces PR-only to `master`, green CI at merge, and real-name identity tagging.

<sup>Written for commit f09072d39823b364dcb3ed047e17f53b4949279c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

