### PR TITLE
[http2-engineer] phase-1 / HTTP/2 server v1

### DIFF
--- a/phase1/http2/Makefile
+++ b/phase1/http2/Makefile
@@ -1,0 +1,60 @@
+EXTRA_CFLAGS += -Iinclude
+
+include ../Makefile.common
+
+IO ?= epoll
+BUILD_DIR := build
+COMMON_SRCS := src/frame.c src/hpack_static.c src/hpack.c src/stream.c src/connection.c src/server.c
+SERVER_SRCS := $(COMMON_SRCS) src/main.c
+
+ifeq ($(PLATFORM),macos)
+  BACKEND_SRC := src/io_kqueue.c
+  BACKEND_CFLAGS := -DHTTP2_BACKEND_KQUEUE
+else ifeq ($(PLATFORM),linux)
+  ifeq ($(IO),epoll)
+    BACKEND_SRC := src/io_epoll.c
+    BACKEND_CFLAGS := -DHTTP2_BACKEND_EPOLL
+  else ifeq ($(IO),io_uring)
+    BACKEND_SRC := src/io_uring.c
+    BACKEND_CFLAGS := -DHTTP2_BACKEND_IO_URING
+  else
+    $(error IO must be epoll or io_uring on Linux)
+  endif
+else
+  $(error unsupported platform $(UNAME_S))
+endif
+
+TEST_COMMON := src/frame.c src/hpack_static.c src/hpack.c src/stream.c src/connection.c
+
+.PHONY: all test smoke clean print-backend
+
+all: $(BUILD_DIR)/h2d
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/h2d: $(SERVER_SRCS) $(BACKEND_SRC) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(BACKEND_CFLAGS) $(SERVER_SRCS) $(BACKEND_SRC) -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/frame_test: tests/frame_test.c src/frame.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) tests/frame_test.c src/frame.c -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/hpack_test: tests/hpack_test.c src/frame.c src/hpack_static.c src/hpack.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) tests/hpack_test.c src/frame.c src/hpack_static.c src/hpack.c -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/connection_test: tests/connection_test.c $(TEST_COMMON) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) tests/connection_test.c $(TEST_COMMON) -o $@ $(LDFLAGS)
+
+test: $(BUILD_DIR)/frame_test $(BUILD_DIR)/hpack_test $(BUILD_DIR)/connection_test
+	$(BUILD_DIR)/frame_test
+	$(BUILD_DIR)/hpack_test
+	$(BUILD_DIR)/connection_test
+
+smoke: $(BUILD_DIR)/h2d
+	bash tests/smoke.sh
+
+print-backend:
+	@echo "PLATFORM=$(PLATFORM) IO=$(IO) BACKEND_SRC=$(BACKEND_SRC) BACKEND_CFLAGS=$(BACKEND_CFLAGS)"
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/phase1/http2/include/http2/connection.h
+++ b/phase1/http2/include/http2/connection.h
@@ -1,0 +1,47 @@
+#ifndef HTTP2_CONNECTION_H
+#define HTTP2_CONNECTION_H
+
+#include "http2/stream.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define H2_CLIENT_PREFACE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+#define H2_CLIENT_PREFACE_LEN 24u
+#define H2_CONN_INPUT_CAP 131072u
+#define H2_CONN_OUTPUT_CAP 131072u
+#define H2_CONN_MAX_STREAMS 128u
+
+typedef struct h2_connection {
+    bool preface_seen;
+    bool settings_sent;
+    bool goaway_sent;
+    uint32_t goaway_error;
+    uint32_t last_stream_id;
+    uint32_t max_frame_size;
+    int32_t initial_stream_window;
+    int32_t conn_send_window;
+    int32_t conn_recv_window;
+    uint32_t responses_sent;
+    bool header_block_open;
+    uint32_t header_block_stream_id;
+    uint8_t header_block_flags;
+    uint8_t header_block[65536];
+    size_t header_block_len;
+    h2_stream streams[H2_CONN_MAX_STREAMS];
+    uint8_t input[H2_CONN_INPUT_CAP];
+    size_t input_len;
+    uint8_t output[H2_CONN_OUTPUT_CAP];
+    size_t output_len;
+    size_t output_sent;
+} h2_connection;
+
+void h2_connection_init(h2_connection *conn);
+int h2_connection_feed(h2_connection *conn, const uint8_t *data, size_t data_len);
+bool h2_connection_wants_write(const h2_connection *conn);
+const uint8_t *h2_connection_output(const h2_connection *conn);
+size_t h2_connection_output_len(const h2_connection *conn);
+void h2_connection_consume_output(h2_connection *conn, size_t sent_len);
+
+#endif

--- a/phase1/http2/include/http2/frame.h
+++ b/phase1/http2/include/http2/frame.h
@@ -1,0 +1,137 @@
+#ifndef HTTP2_FRAME_H
+#define HTTP2_FRAME_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define H2_FRAME_HEADER_LEN 9u
+#define H2_DEFAULT_MAX_FRAME_SIZE 16384u
+#define H2_MAX_FRAME_SIZE 16777215u
+#define H2_DEFAULT_WINDOW_SIZE 65535
+
+typedef enum h2_error_code {
+    H2_OK = 0x0,
+    H2_PROTOCOL_ERROR = 0x1,
+    H2_INTERNAL_ERROR = 0x2,
+    H2_FLOW_CONTROL_ERROR = 0x3,
+    H2_SETTINGS_TIMEOUT = 0x4,
+    H2_STREAM_CLOSED = 0x5,
+    H2_FRAME_SIZE_ERROR = 0x6,
+    H2_REFUSED_STREAM = 0x7,
+    H2_CANCEL = 0x8,
+    H2_COMPRESSION_ERROR = 0x9,
+    H2_CONNECT_ERROR = 0xa,
+    H2_ENHANCE_YOUR_CALM = 0xb,
+    H2_INADEQUATE_SECURITY = 0xc,
+    H2_HTTP_1_1_REQUIRED = 0xd
+} h2_error_code;
+
+typedef enum h2_frame_type {
+    H2_FRAME_DATA = 0x0,
+    H2_FRAME_HEADERS = 0x1,
+    H2_FRAME_PRIORITY = 0x2,
+    H2_FRAME_RST_STREAM = 0x3,
+    H2_FRAME_SETTINGS = 0x4,
+    H2_FRAME_PUSH_PROMISE = 0x5,
+    H2_FRAME_PING = 0x6,
+    H2_FRAME_GOAWAY = 0x7,
+    H2_FRAME_WINDOW_UPDATE = 0x8,
+    H2_FRAME_CONTINUATION = 0x9
+} h2_frame_type;
+
+enum h2_frame_flags {
+    H2_FLAG_END_STREAM = 0x1,
+    H2_FLAG_ACK = 0x1,
+    H2_FLAG_END_HEADERS = 0x4,
+    H2_FLAG_PADDED = 0x8,
+    H2_FLAG_PRIORITY = 0x20
+};
+
+typedef enum h2_settings_id {
+    H2_SETTINGS_HEADER_TABLE_SIZE = 0x1,
+    H2_SETTINGS_ENABLE_PUSH = 0x2,
+    H2_SETTINGS_MAX_CONCURRENT_STREAMS = 0x3,
+    H2_SETTINGS_INITIAL_WINDOW_SIZE = 0x4,
+    H2_SETTINGS_MAX_FRAME_SIZE = 0x5,
+    H2_SETTINGS_MAX_HEADER_LIST_SIZE = 0x6
+} h2_settings_id;
+
+typedef struct h2_frame_header {
+    uint32_t length;
+    uint8_t type;
+    uint8_t flags;
+    uint32_t stream_id;
+} h2_frame_header;
+
+typedef struct h2_setting {
+    uint16_t id;
+    uint32_t value;
+} h2_setting;
+
+typedef struct h2_priority_payload {
+    bool exclusive;
+    uint32_t stream_dependency;
+    uint8_t weight;
+} h2_priority_payload;
+
+typedef struct h2_data_payload {
+    const uint8_t *data;
+    size_t data_len;
+    uint8_t pad_len;
+} h2_data_payload;
+
+typedef struct h2_headers_payload {
+    const uint8_t *header_block;
+    size_t header_block_len;
+    uint8_t pad_len;
+    bool has_priority;
+    h2_priority_payload priority;
+} h2_headers_payload;
+
+typedef struct h2_push_promise_payload {
+    uint32_t promised_stream_id;
+    const uint8_t *header_block;
+    size_t header_block_len;
+    uint8_t pad_len;
+} h2_push_promise_payload;
+
+typedef struct h2_goaway_payload {
+    uint32_t last_stream_id;
+    uint32_t error_code;
+    const uint8_t *debug_data;
+    size_t debug_len;
+} h2_goaway_payload;
+
+typedef struct h2_continuation_payload {
+    const uint8_t *header_block;
+    size_t header_block_len;
+} h2_continuation_payload;
+
+int h2_frame_parse_header(const uint8_t *wire, size_t wire_len, h2_frame_header *out);
+int h2_frame_write_header(uint8_t *wire, size_t cap, const h2_frame_header *header);
+int h2_frame_validate_payload(const h2_frame_header *header);
+
+int h2_frame_parse_data(const h2_frame_header *header, const uint8_t *payload, h2_data_payload *out);
+int h2_frame_parse_headers(const h2_frame_header *header, const uint8_t *payload, h2_headers_payload *out);
+int h2_frame_parse_priority(const h2_frame_header *header, const uint8_t *payload, h2_priority_payload *out);
+int h2_frame_parse_settings(const h2_frame_header *header, const uint8_t *payload, h2_setting *settings, size_t max_settings, size_t *settings_len);
+int h2_frame_parse_window_update(const h2_frame_header *header, const uint8_t *payload, uint32_t *increment);
+int h2_frame_parse_ping(const h2_frame_header *header, const uint8_t *payload, uint8_t opaque[8]);
+int h2_frame_parse_goaway(const h2_frame_header *header, const uint8_t *payload, h2_goaway_payload *out);
+int h2_frame_parse_rst_stream(const h2_frame_header *header, const uint8_t *payload, uint32_t *error_code);
+int h2_frame_parse_continuation(const h2_frame_header *header, const uint8_t *payload, h2_continuation_payload *out);
+int h2_frame_parse_push_promise(const h2_frame_header *header, const uint8_t *payload, h2_push_promise_payload *out);
+
+size_t h2_frame_encode_data(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *data, size_t data_len);
+size_t h2_frame_encode_headers(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *header_block, size_t header_block_len);
+size_t h2_frame_encode_priority(uint8_t *wire, size_t cap, uint32_t stream_id, const h2_priority_payload *priority);
+size_t h2_frame_encode_rst_stream(uint8_t *wire, size_t cap, uint32_t stream_id, uint32_t error_code);
+size_t h2_frame_encode_settings(uint8_t *wire, size_t cap, uint8_t flags, const h2_setting *settings, size_t settings_len);
+size_t h2_frame_encode_push_promise(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, uint32_t promised_stream_id, const uint8_t *header_block, size_t header_block_len);
+size_t h2_frame_encode_ping(uint8_t *wire, size_t cap, uint8_t flags, const uint8_t opaque[8]);
+size_t h2_frame_encode_goaway(uint8_t *wire, size_t cap, uint32_t last_stream_id, uint32_t error_code, const uint8_t *debug_data, size_t debug_len);
+size_t h2_frame_encode_window_update(uint8_t *wire, size_t cap, uint32_t stream_id, uint32_t increment);
+size_t h2_frame_encode_continuation(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *header_block, size_t header_block_len);
+
+#endif

--- a/phase1/http2/include/http2/hpack.h
+++ b/phase1/http2/include/http2/hpack.h
@@ -1,0 +1,22 @@
+#ifndef HTTP2_HPACK_H
+#define HTTP2_HPACK_H
+
+#include "http2/frame.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct h2_header_field {
+    char name[64];
+    char value[256];
+} h2_header_field;
+
+int h2_hpack_decode_integer(const uint8_t *wire, size_t wire_len, uint8_t prefix_bits, uint32_t *value, size_t *used);
+size_t h2_hpack_encode_integer(uint8_t *wire, size_t cap, uint8_t prefix_bits, uint8_t high_bits, uint32_t value);
+size_t h2_hpack_encode_indexed(uint8_t *wire, size_t cap, uint32_t static_index);
+size_t h2_hpack_encode_string(uint8_t *wire, size_t cap, const char *text);
+size_t h2_hpack_encode_literal_new_name(uint8_t *wire, size_t cap, const char *name, const char *value);
+int h2_hpack_decode_headers(const uint8_t *wire, size_t wire_len, h2_header_field *fields, size_t field_cap, size_t *field_len);
+int h2_hpack_extract_path(const uint8_t *wire, size_t wire_len, char *path, size_t path_cap);
+
+#endif

--- a/phase1/http2/include/http2/hpack_static.h
+++ b/phase1/http2/include/http2/hpack_static.h
@@ -1,0 +1,15 @@
+#ifndef HTTP2_HPACK_STATIC_H
+#define HTTP2_HPACK_STATIC_H
+
+#include <stdint.h>
+
+#define H2_HPACK_STATIC_TABLE_LEN 61u
+
+typedef struct h2_hpack_static_entry {
+    const char *name;
+    const char *value;
+} h2_hpack_static_entry;
+
+const h2_hpack_static_entry *h2_hpack_static_get(uint32_t index);
+
+#endif

--- a/phase1/http2/include/http2/io.h
+++ b/phase1/http2/include/http2/io.h
@@ -1,0 +1,28 @@
+#ifndef HTTP2_IO_H
+#define HTTP2_IO_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct h2_io {
+    int fd;
+    void *state;
+} h2_io;
+
+typedef struct h2_event {
+    int fd;
+    bool readable;
+    bool writable;
+    bool closed;
+} h2_event;
+
+const char *h2_io_backend_name(void);
+int h2_io_init(h2_io *io);
+int h2_io_add_listener(h2_io *io, int fd);
+int h2_io_add_connection(h2_io *io, int fd);
+int h2_io_mod_connection(h2_io *io, int fd, bool want_write);
+int h2_io_remove(h2_io *io, int fd);
+int h2_io_wait(h2_io *io, h2_event *events, size_t event_cap, int timeout_ms);
+void h2_io_close(h2_io *io);
+
+#endif

--- a/phase1/http2/include/http2/server.h
+++ b/phase1/http2/include/http2/server.h
@@ -1,0 +1,15 @@
+#ifndef HTTP2_SERVER_H
+#define HTTP2_SERVER_H
+
+#include <stdint.h>
+
+typedef struct h2_server_config {
+    const char *host;
+    uint16_t port;
+    const char *ready_file;
+    unsigned max_connections;
+} h2_server_config;
+
+int h2_server_run(const h2_server_config *config);
+
+#endif

--- a/phase1/http2/include/http2/stream.h
+++ b/phase1/http2/include/http2/stream.h
@@ -1,0 +1,33 @@
+#ifndef HTTP2_STREAM_H
+#define HTTP2_STREAM_H
+
+#include "http2/frame.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum h2_stream_state {
+    H2_STREAM_STATE_IDLE,
+    H2_STREAM_STATE_OPEN,
+    H2_STREAM_STATE_HALF_CLOSED_REMOTE,
+    H2_STREAM_STATE_HALF_CLOSED_LOCAL,
+    H2_STREAM_STATE_CLOSED
+} h2_stream_state;
+
+typedef struct h2_stream {
+    uint32_t id;
+    h2_stream_state state;
+    int32_t send_window;
+    int32_t recv_window;
+    bool response_sent;
+    char path[256];
+} h2_stream;
+
+void h2_stream_init(h2_stream *stream, uint32_t stream_id, int32_t initial_window);
+int h2_stream_receive_headers(h2_stream *stream, bool end_stream);
+int h2_stream_receive_data(h2_stream *stream, size_t data_len, bool end_stream);
+int h2_stream_send_end_stream(h2_stream *stream);
+int h2_stream_add_send_window(h2_stream *stream, uint32_t increment);
+
+#endif

--- a/phase1/http2/src/connection.c
+++ b/phase1/http2/src/connection.c
@@ -1,0 +1,564 @@
+#include "http2/connection.h"
+
+#include "http2/hpack.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+
+static void h2_connection_compact_output(h2_connection *conn)
+{
+    if (conn->output_sent == 0u) {
+        return;
+    }
+    if (conn->output_sent >= conn->output_len) {
+        conn->output_len = 0u;
+        conn->output_sent = 0u;
+        return;
+    }
+    memmove(conn->output, conn->output + conn->output_sent, conn->output_len - conn->output_sent);
+    conn->output_len -= conn->output_sent;
+    conn->output_sent = 0u;
+}
+
+static int h2_connection_queue_bytes(h2_connection *conn, const uint8_t *data, size_t data_len)
+{
+    h2_connection_compact_output(conn);
+    if (data_len > H2_CONN_OUTPUT_CAP - conn->output_len || (data_len > 0u && data == NULL)) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (data_len > 0u) {
+        memcpy(conn->output + conn->output_len, data, data_len);
+        conn->output_len += data_len;
+    }
+    return H2_OK;
+}
+
+static int h2_connection_queue_goaway(h2_connection *conn, uint32_t error_code)
+{
+    uint8_t wire[H2_FRAME_HEADER_LEN + 8u];
+    size_t wire_len;
+
+    if (conn->goaway_sent) {
+        return H2_OK;
+    }
+    wire_len = h2_frame_encode_goaway(wire, sizeof(wire), conn->last_stream_id, error_code, NULL, 0u);
+    if (wire_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    conn->goaway_sent = true;
+    conn->goaway_error = error_code;
+    return h2_connection_queue_bytes(conn, wire, wire_len);
+}
+
+static int h2_connection_queue_settings(h2_connection *conn)
+{
+    h2_setting settings[1];
+    uint8_t wire[H2_FRAME_HEADER_LEN + 6u];
+    size_t wire_len;
+
+    settings[0].id = H2_SETTINGS_ENABLE_PUSH;
+    settings[0].value = 0u;
+    wire_len = h2_frame_encode_settings(wire, sizeof(wire), 0u, settings, 1u);
+    if (wire_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    return h2_connection_queue_bytes(conn, wire, wire_len);
+}
+
+static int h2_connection_queue_settings_ack(h2_connection *conn)
+{
+    uint8_t wire[H2_FRAME_HEADER_LEN];
+    size_t wire_len;
+
+    wire_len = h2_frame_encode_settings(wire, sizeof(wire), H2_FLAG_ACK, NULL, 0u);
+    if (wire_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    return h2_connection_queue_bytes(conn, wire, wire_len);
+}
+
+static int h2_connection_queue_window_update(h2_connection *conn, uint32_t stream_id, uint32_t increment)
+{
+    uint8_t wire[H2_FRAME_HEADER_LEN + 4u];
+    size_t wire_len;
+
+    wire_len = h2_frame_encode_window_update(wire, sizeof(wire), stream_id, increment);
+    if (wire_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    return h2_connection_queue_bytes(conn, wire, wire_len);
+}
+
+static h2_stream *h2_connection_find_stream(h2_connection *conn, uint32_t stream_id)
+{
+    size_t pos;
+
+    for (pos = 0u; pos < H2_CONN_MAX_STREAMS; pos++) {
+        if (conn->streams[pos].id == stream_id) {
+            return &conn->streams[pos];
+        }
+    }
+    return NULL;
+}
+
+static h2_stream *h2_connection_get_stream(h2_connection *conn, uint32_t stream_id)
+{
+    h2_stream *stream;
+    size_t pos;
+
+    stream = h2_connection_find_stream(conn, stream_id);
+    if (stream != NULL) {
+        return stream;
+    }
+    for (pos = 0u; pos < H2_CONN_MAX_STREAMS; pos++) {
+        if (conn->streams[pos].id == 0u) {
+            h2_stream_init(&conn->streams[pos], stream_id, conn->initial_stream_window);
+            return &conn->streams[pos];
+        }
+    }
+    return NULL;
+}
+
+static int h2_connection_refresh_recv_windows(h2_connection *conn, h2_stream *stream)
+{
+    if (conn->conn_recv_window <= H2_DEFAULT_WINDOW_SIZE / 2) {
+        uint32_t increment;
+
+        increment = (uint32_t)(H2_DEFAULT_WINDOW_SIZE - conn->conn_recv_window);
+        conn->conn_recv_window += (int32_t)increment;
+        if (h2_connection_queue_window_update(conn, 0u, increment) != H2_OK) {
+            return H2_INTERNAL_ERROR;
+        }
+    }
+    if (stream != NULL && stream->recv_window <= H2_DEFAULT_WINDOW_SIZE / 2) {
+        uint32_t increment;
+
+        increment = (uint32_t)(H2_DEFAULT_WINDOW_SIZE - stream->recv_window);
+        stream->recv_window += (int32_t)increment;
+        if (h2_connection_queue_window_update(conn, stream->id, increment) != H2_OK) {
+            return H2_INTERNAL_ERROR;
+        }
+    }
+    return H2_OK;
+}
+
+static int h2_connection_apply_settings(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    h2_setting settings[32];
+    size_t settings_len;
+    size_t pos;
+    int ret;
+
+    ret = h2_frame_parse_settings(header, payload, settings, sizeof(settings) / sizeof(settings[0]), &settings_len);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    if ((header->flags & H2_FLAG_ACK) != 0u) {
+        return H2_OK;
+    }
+    for (pos = 0u; pos < settings_len; pos++) {
+        if (settings[pos].id == H2_SETTINGS_ENABLE_PUSH) {
+            if (settings[pos].value > 1u) {
+                return H2_PROTOCOL_ERROR;
+            }
+        } else if (settings[pos].id == H2_SETTINGS_INITIAL_WINDOW_SIZE) {
+            int64_t delta;
+            size_t stream_pos;
+
+            if (settings[pos].value > INT32_MAX) {
+                return H2_FLOW_CONTROL_ERROR;
+            }
+            delta = (int64_t)settings[pos].value - (int64_t)conn->initial_stream_window;
+            for (stream_pos = 0u; stream_pos < H2_CONN_MAX_STREAMS; stream_pos++) {
+                if (conn->streams[stream_pos].id != 0u) {
+                    int64_t new_window;
+
+                    new_window = (int64_t)conn->streams[stream_pos].send_window + delta;
+                    if (new_window < INT32_MIN || new_window > INT32_MAX) {
+                        return H2_FLOW_CONTROL_ERROR;
+                    }
+                    conn->streams[stream_pos].send_window = (int32_t)new_window;
+                }
+            }
+            conn->initial_stream_window = (int32_t)settings[pos].value;
+        } else if (settings[pos].id == H2_SETTINGS_MAX_FRAME_SIZE) {
+            if (settings[pos].value < H2_DEFAULT_MAX_FRAME_SIZE || settings[pos].value > H2_MAX_FRAME_SIZE) {
+                return H2_PROTOCOL_ERROR;
+            }
+            conn->max_frame_size = settings[pos].value;
+        }
+    }
+    return h2_connection_queue_settings_ack(conn);
+}
+
+static int h2_connection_queue_response(h2_connection *conn, h2_stream *stream)
+{
+    uint8_t header_block[512];
+    uint8_t wire[H2_FRAME_HEADER_LEN + 1024u];
+    char content_length[32];
+    char body[320];
+    size_t body_len;
+    size_t pos;
+    size_t chunk_len;
+    size_t wire_len;
+    int printed;
+
+    if (stream->response_sent) {
+        return H2_OK;
+    }
+    if (stream->path[0] == '\0') {
+        if (sizeof(stream->path) < 2u) {
+            return H2_INTERNAL_ERROR;
+        }
+        stream->path[0] = '/';
+        stream->path[1] = '\0';
+    }
+    printed = snprintf(body, sizeof(body), "%s\n", stream->path);
+    if (printed < 0 || (size_t)printed >= sizeof(body)) {
+        return H2_INTERNAL_ERROR;
+    }
+    body_len = (size_t)printed;
+    printed = snprintf(content_length, sizeof(content_length), "%zu", body_len);
+    if (printed < 0 || (size_t)printed >= sizeof(content_length)) {
+        return H2_INTERNAL_ERROR;
+    }
+
+    pos = 0u;
+    chunk_len = h2_hpack_encode_indexed(header_block + pos, sizeof(header_block) - pos, 8u);
+    if (chunk_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_literal_new_name(header_block + pos, sizeof(header_block) - pos, "content-type", "text/plain");
+    if (chunk_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_literal_new_name(header_block + pos, sizeof(header_block) - pos, "content-length", content_length);
+    if (chunk_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_literal_new_name(header_block + pos, sizeof(header_block) - pos, "server", "c11-h2");
+    if (chunk_len == 0u) {
+        return H2_INTERNAL_ERROR;
+    }
+    pos += chunk_len;
+
+    wire_len = h2_frame_encode_headers(wire, sizeof(wire), stream->id, H2_FLAG_END_HEADERS, header_block, pos);
+    if (wire_len == 0u || h2_connection_queue_bytes(conn, wire, wire_len) != H2_OK) {
+        return H2_INTERNAL_ERROR;
+    }
+    if ((size_t)conn->conn_send_window < body_len || (size_t)stream->send_window < body_len) {
+        return H2_FLOW_CONTROL_ERROR;
+    }
+    wire_len = h2_frame_encode_data(wire, sizeof(wire), stream->id, H2_FLAG_END_STREAM, (const uint8_t *)body, body_len);
+    if (wire_len == 0u || h2_connection_queue_bytes(conn, wire, wire_len) != H2_OK) {
+        return H2_INTERNAL_ERROR;
+    }
+    conn->conn_send_window -= (int32_t)body_len;
+    stream->send_window -= (int32_t)body_len;
+    stream->response_sent = true;
+    conn->responses_sent++;
+    return h2_stream_send_end_stream(stream);
+}
+
+static int h2_connection_finish_headers(h2_connection *conn, uint32_t stream_id, uint8_t flags, const uint8_t *header_block, size_t header_block_len)
+{
+    h2_stream *stream;
+    int ret;
+
+    if ((stream_id & 1u) == 0u) {
+        return H2_PROTOCOL_ERROR;
+    }
+    stream = h2_connection_get_stream(conn, stream_id);
+    if (stream == NULL) {
+        return H2_REFUSED_STREAM;
+    }
+    if (stream_id > conn->last_stream_id) {
+        conn->last_stream_id = stream_id;
+    }
+    ret = h2_hpack_extract_path(header_block, header_block_len, stream->path, sizeof(stream->path));
+    if (ret != H2_OK) {
+        return ret;
+    }
+    ret = h2_stream_receive_headers(stream, (flags & H2_FLAG_END_STREAM) != 0u);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    return h2_connection_queue_response(conn, stream);
+}
+
+static int h2_connection_append_header_block(h2_connection *conn, const uint8_t *data, size_t data_len)
+{
+    if (data_len > sizeof(conn->header_block) - conn->header_block_len) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if (data_len > 0u) {
+        memcpy(conn->header_block + conn->header_block_len, data, data_len);
+        conn->header_block_len += data_len;
+    }
+    return H2_OK;
+}
+
+static int h2_connection_process_headers(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    h2_headers_payload parsed;
+    int ret;
+
+    ret = h2_frame_parse_headers(header, payload, &parsed);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    if ((header->flags & H2_FLAG_END_HEADERS) == 0u) {
+        if (conn->header_block_open) {
+            return H2_PROTOCOL_ERROR;
+        }
+        conn->header_block_open = true;
+        conn->header_block_stream_id = header->stream_id;
+        conn->header_block_flags = header->flags;
+        conn->header_block_len = 0u;
+        return h2_connection_append_header_block(conn, parsed.header_block, parsed.header_block_len);
+    }
+    return h2_connection_finish_headers(conn, header->stream_id, header->flags, parsed.header_block, parsed.header_block_len);
+}
+
+static int h2_connection_process_continuation(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    h2_continuation_payload parsed;
+    int ret;
+
+    if (!conn->header_block_open || header->stream_id != conn->header_block_stream_id) {
+        return H2_PROTOCOL_ERROR;
+    }
+    ret = h2_frame_parse_continuation(header, payload, &parsed);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    ret = h2_connection_append_header_block(conn, parsed.header_block, parsed.header_block_len);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    if ((header->flags & H2_FLAG_END_HEADERS) == 0u) {
+        return H2_OK;
+    }
+
+    conn->header_block_open = false;
+    return h2_connection_finish_headers(conn, conn->header_block_stream_id, conn->header_block_flags, conn->header_block, conn->header_block_len);
+}
+
+static int h2_connection_process_data(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    h2_data_payload parsed;
+    h2_stream *stream;
+    int ret;
+
+    ret = h2_frame_parse_data(header, payload, &parsed);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    stream = h2_connection_get_stream(conn, header->stream_id);
+    if (stream == NULL) {
+        return H2_REFUSED_STREAM;
+    }
+    if ((size_t)conn->conn_recv_window < header->length) {
+        return H2_FLOW_CONTROL_ERROR;
+    }
+    conn->conn_recv_window -= (int32_t)header->length;
+    ret = h2_stream_receive_data(stream, header->length, (header->flags & H2_FLAG_END_STREAM) != 0u);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    (void)parsed;
+    return h2_connection_refresh_recv_windows(conn, stream);
+}
+
+static int h2_connection_process_window_update(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    uint32_t increment;
+    int ret;
+
+    ret = h2_frame_parse_window_update(header, payload, &increment);
+    if (ret != H2_OK) {
+        return ret;
+    }
+    if (header->stream_id == 0u) {
+        if (increment > (uint32_t)(INT32_MAX - conn->conn_send_window)) {
+            return H2_FLOW_CONTROL_ERROR;
+        }
+        conn->conn_send_window += (int32_t)increment;
+        return H2_OK;
+    }
+    return h2_stream_add_send_window(h2_connection_get_stream(conn, header->stream_id), increment);
+}
+
+static int h2_connection_process_frame(h2_connection *conn, const h2_frame_header *header, const uint8_t *payload)
+{
+    int ret;
+
+    if (header->length > conn->max_frame_size) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+    if (conn->header_block_open && (header->type != H2_FRAME_CONTINUATION || header->stream_id != conn->header_block_stream_id)) {
+        return H2_PROTOCOL_ERROR;
+    }
+
+    switch (header->type) {
+    case H2_FRAME_DATA:
+        return h2_connection_process_data(conn, header, payload);
+    case H2_FRAME_HEADERS:
+        return h2_connection_process_headers(conn, header, payload);
+    case H2_FRAME_PRIORITY:
+        ret = h2_frame_validate_payload(header);
+        if (ret != H2_OK) {
+            return ret;
+        }
+        return H2_OK;
+    case H2_FRAME_RST_STREAM: {
+        h2_stream *stream;
+        uint32_t error_code;
+
+        ret = h2_frame_parse_rst_stream(header, payload, &error_code);
+        if (ret != H2_OK) {
+            return ret;
+        }
+        stream = h2_connection_get_stream(conn, header->stream_id);
+        if (stream != NULL) {
+            stream->state = H2_STREAM_STATE_CLOSED;
+        }
+        (void)error_code;
+        return H2_OK;
+    }
+    case H2_FRAME_SETTINGS:
+        return h2_connection_apply_settings(conn, header, payload);
+    case H2_FRAME_PUSH_PROMISE:
+        return H2_PROTOCOL_ERROR;
+    case H2_FRAME_PING: {
+        uint8_t opaque[8];
+        uint8_t wire[H2_FRAME_HEADER_LEN + 8u];
+        size_t wire_len;
+
+        ret = h2_frame_parse_ping(header, payload, opaque);
+        if (ret != H2_OK || (header->flags & H2_FLAG_ACK) != 0u) {
+            return ret;
+        }
+        wire_len = h2_frame_encode_ping(wire, sizeof(wire), H2_FLAG_ACK, opaque);
+        if (wire_len == 0u) {
+            return H2_INTERNAL_ERROR;
+        }
+        return h2_connection_queue_bytes(conn, wire, wire_len);
+    }
+    case H2_FRAME_GOAWAY:
+        return h2_frame_validate_payload(header);
+    case H2_FRAME_WINDOW_UPDATE:
+        return h2_connection_process_window_update(conn, header, payload);
+    case H2_FRAME_CONTINUATION:
+        return h2_connection_process_continuation(conn, header, payload);
+    default:
+        return H2_OK;
+    }
+}
+
+void h2_connection_init(h2_connection *conn)
+{
+    memset(conn, 0, sizeof(*conn));
+    conn->max_frame_size = H2_DEFAULT_MAX_FRAME_SIZE;
+    conn->initial_stream_window = H2_DEFAULT_WINDOW_SIZE;
+    conn->conn_send_window = H2_DEFAULT_WINDOW_SIZE;
+    conn->conn_recv_window = H2_DEFAULT_WINDOW_SIZE;
+}
+
+int h2_connection_feed(h2_connection *conn, const uint8_t *data, size_t data_len)
+{
+    if (conn == NULL || (data == NULL && data_len > 0u)) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (data_len > H2_CONN_INPUT_CAP - conn->input_len) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (data_len > 0u) {
+        memcpy(conn->input + conn->input_len, data, data_len);
+        conn->input_len += data_len;
+    }
+    if (!conn->preface_seen) {
+        if (conn->input_len < H2_CLIENT_PREFACE_LEN) {
+            return H2_OK;
+        }
+        if (memcmp(conn->input, H2_CLIENT_PREFACE, H2_CLIENT_PREFACE_LEN) != 0) {
+            (void)h2_connection_queue_goaway(conn, H2_PROTOCOL_ERROR);
+            return H2_PROTOCOL_ERROR;
+        }
+        memmove(conn->input, conn->input + H2_CLIENT_PREFACE_LEN, conn->input_len - H2_CLIENT_PREFACE_LEN);
+        conn->input_len -= H2_CLIENT_PREFACE_LEN;
+        conn->preface_seen = true;
+        if (!conn->settings_sent) {
+            int ret;
+
+            ret = h2_connection_queue_settings(conn);
+            if (ret != H2_OK) {
+                return ret;
+            }
+            conn->settings_sent = true;
+        }
+    }
+
+    while (conn->input_len >= H2_FRAME_HEADER_LEN) {
+        h2_frame_header header;
+        size_t whole_len;
+        int ret;
+
+        ret = h2_frame_parse_header(conn->input, conn->input_len, &header);
+        if (ret != H2_OK) {
+            return ret;
+        }
+        whole_len = H2_FRAME_HEADER_LEN + (size_t)header.length;
+        if (whole_len > conn->input_len) {
+            break;
+        }
+        ret = h2_connection_process_frame(conn, &header, conn->input + H2_FRAME_HEADER_LEN);
+        if (ret != H2_OK) {
+            (void)h2_connection_queue_goaway(conn, (uint32_t)ret);
+            return ret;
+        }
+        memmove(conn->input, conn->input + whole_len, conn->input_len - whole_len);
+        conn->input_len -= whole_len;
+    }
+    return H2_OK;
+}
+
+bool h2_connection_wants_write(const h2_connection *conn)
+{
+    return conn != NULL && conn->output_sent < conn->output_len;
+}
+
+const uint8_t *h2_connection_output(const h2_connection *conn)
+{
+    if (conn == NULL || conn->output_sent >= conn->output_len) {
+        return NULL;
+    }
+    return conn->output + conn->output_sent;
+}
+
+size_t h2_connection_output_len(const h2_connection *conn)
+{
+    if (conn == NULL || conn->output_sent >= conn->output_len) {
+        return 0u;
+    }
+    return conn->output_len - conn->output_sent;
+}
+
+void h2_connection_consume_output(h2_connection *conn, size_t sent_len)
+{
+    size_t available;
+
+    if (conn == NULL) {
+        return;
+    }
+    available = h2_connection_output_len(conn);
+    if (sent_len > available) {
+        sent_len = available;
+    }
+    conn->output_sent += sent_len;
+    h2_connection_compact_output(conn);
+}

--- a/phase1/http2/src/frame.c
+++ b/phase1/http2/src/frame.c
@@ -1,0 +1,524 @@
+#include "http2/frame.h"
+
+#include <string.h>
+
+static uint16_t h2_read_u16(const uint8_t *wire)
+{
+    return (uint16_t)(((uint16_t)wire[0] << 8u) | (uint16_t)wire[1]);
+}
+
+static uint32_t h2_read_u31(const uint8_t *wire)
+{
+    return (((uint32_t)wire[0] & 0x7fu) << 24u) |
+        ((uint32_t)wire[1] << 16u) |
+        ((uint32_t)wire[2] << 8u) |
+        (uint32_t)wire[3];
+}
+
+static uint32_t h2_read_u32(const uint8_t *wire)
+{
+    return ((uint32_t)wire[0] << 24u) |
+        ((uint32_t)wire[1] << 16u) |
+        ((uint32_t)wire[2] << 8u) |
+        (uint32_t)wire[3];
+}
+
+static void h2_write_u16(uint8_t *wire, uint16_t value)
+{
+    wire[0] = (uint8_t)(value >> 8u);
+    wire[1] = (uint8_t)value;
+}
+
+static void h2_write_u32(uint8_t *wire, uint32_t value)
+{
+    wire[0] = (uint8_t)(value >> 24u);
+    wire[1] = (uint8_t)(value >> 16u);
+    wire[2] = (uint8_t)(value >> 8u);
+    wire[3] = (uint8_t)value;
+}
+
+static int h2_validate_stream_nonzero(const h2_frame_header *header)
+{
+    return header->stream_id == 0u ? H2_PROTOCOL_ERROR : H2_OK;
+}
+
+int h2_frame_parse_header(const uint8_t *wire, size_t wire_len, h2_frame_header *out)
+{
+    if (wire == NULL || out == NULL || wire_len < H2_FRAME_HEADER_LEN) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+
+    out->length = ((uint32_t)wire[0] << 16u) | ((uint32_t)wire[1] << 8u) | (uint32_t)wire[2];
+    out->type = wire[3];
+    out->flags = wire[4];
+    out->stream_id = h2_read_u31(wire + 5u);
+    return H2_OK;
+}
+
+int h2_frame_write_header(uint8_t *wire, size_t cap, const h2_frame_header *header)
+{
+    if (wire == NULL || header == NULL || cap < H2_FRAME_HEADER_LEN || header->length > H2_MAX_FRAME_SIZE) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+
+    wire[0] = (uint8_t)(header->length >> 16u);
+    wire[1] = (uint8_t)(header->length >> 8u);
+    wire[2] = (uint8_t)header->length;
+    wire[3] = header->type;
+    wire[4] = header->flags;
+    h2_write_u32(wire + 5u, header->stream_id & 0x7fffffffu);
+    return H2_OK;
+}
+
+int h2_frame_validate_payload(const h2_frame_header *header)
+{
+    if (header == NULL || header->length > H2_MAX_FRAME_SIZE) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+
+    switch (header->type) {
+    case H2_FRAME_DATA:
+        return h2_validate_stream_nonzero(header);
+    case H2_FRAME_HEADERS:
+        return h2_validate_stream_nonzero(header);
+    case H2_FRAME_PRIORITY:
+        if (header->stream_id == 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        return header->length == 5u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_RST_STREAM:
+        if (header->stream_id == 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        return header->length == 4u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_SETTINGS:
+        if (header->stream_id != 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        if ((header->flags & H2_FLAG_ACK) != 0u) {
+            return header->length == 0u ? H2_OK : H2_FRAME_SIZE_ERROR;
+        }
+        return header->length % 6u == 0u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_PUSH_PROMISE:
+        if (header->stream_id == 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        return header->length >= (((header->flags & H2_FLAG_PADDED) != 0u) ? 5u : 4u) ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_PING:
+        if (header->stream_id != 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        return header->length == 8u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_GOAWAY:
+        if (header->stream_id != 0u) {
+            return H2_PROTOCOL_ERROR;
+        }
+        return header->length >= 8u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_WINDOW_UPDATE:
+        return header->length == 4u ? H2_OK : H2_FRAME_SIZE_ERROR;
+    case H2_FRAME_CONTINUATION:
+        return h2_validate_stream_nonzero(header);
+    default:
+        return H2_OK;
+    }
+}
+
+int h2_frame_parse_data(const h2_frame_header *header, const uint8_t *payload, h2_data_payload *out)
+{
+    size_t data_len;
+    uint8_t pad_len;
+
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_DATA || h2_frame_validate_payload(header) != H2_OK) {
+        return H2_PROTOCOL_ERROR;
+    }
+
+    data_len = header->length;
+    pad_len = 0u;
+    if ((header->flags & H2_FLAG_PADDED) != 0u) {
+        if (data_len == 0u) {
+            return H2_FRAME_SIZE_ERROR;
+        }
+        pad_len = payload[0];
+        payload++;
+        data_len--;
+        if ((size_t)pad_len > data_len) {
+            return H2_PROTOCOL_ERROR;
+        }
+        data_len -= pad_len;
+    }
+
+    out->data = payload;
+    out->data_len = data_len;
+    out->pad_len = pad_len;
+    return H2_OK;
+}
+
+int h2_frame_parse_priority(const h2_frame_header *header, const uint8_t *payload, h2_priority_payload *out)
+{
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_PRIORITY || h2_frame_validate_payload(header) != H2_OK) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+
+    out->exclusive = (payload[0] & 0x80u) != 0u;
+    out->stream_dependency = h2_read_u31(payload);
+    out->weight = payload[4];
+    return H2_OK;
+}
+
+int h2_frame_parse_headers(const h2_frame_header *header, const uint8_t *payload, h2_headers_payload *out)
+{
+    size_t block_len;
+    size_t payload_pos;
+    uint8_t pad_len;
+
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_HEADERS || h2_frame_validate_payload(header) != H2_OK) {
+        return H2_PROTOCOL_ERROR;
+    }
+
+    block_len = header->length;
+    payload_pos = 0u;
+    pad_len = 0u;
+    if ((header->flags & H2_FLAG_PADDED) != 0u) {
+        if (block_len == 0u) {
+            return H2_FRAME_SIZE_ERROR;
+        }
+        pad_len = payload[0];
+        payload_pos++;
+        block_len--;
+        if ((size_t)pad_len > block_len) {
+            return H2_PROTOCOL_ERROR;
+        }
+        block_len -= pad_len;
+    }
+    out->has_priority = (header->flags & H2_FLAG_PRIORITY) != 0u;
+    if (out->has_priority) {
+        h2_frame_header priority_header;
+
+        if (block_len < 5u) {
+            return H2_FRAME_SIZE_ERROR;
+        }
+        priority_header.length = 5u;
+        priority_header.type = H2_FRAME_PRIORITY;
+        priority_header.flags = 0u;
+        priority_header.stream_id = header->stream_id;
+        if (h2_frame_parse_priority(&priority_header, payload + payload_pos, &out->priority) != H2_OK) {
+            return H2_FRAME_SIZE_ERROR;
+        }
+        payload_pos += 5u;
+        block_len -= 5u;
+    }
+
+    out->header_block = payload + payload_pos;
+    out->header_block_len = block_len;
+    out->pad_len = pad_len;
+    return H2_OK;
+}
+
+int h2_frame_parse_settings(const h2_frame_header *header, const uint8_t *payload, h2_setting *settings, size_t max_settings, size_t *settings_len)
+{
+    size_t item_count;
+    size_t item_index;
+    int valid;
+
+    if (header == NULL || settings_len == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_SETTINGS) {
+        return H2_PROTOCOL_ERROR;
+    }
+    valid = h2_frame_validate_payload(header);
+    if (valid != H2_OK) {
+        return valid;
+    }
+    if ((header->flags & H2_FLAG_ACK) != 0u) {
+        *settings_len = 0u;
+        return H2_OK;
+    }
+    if (header->length > 0u && payload == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+
+    item_count = header->length / 6u;
+    if (item_count > max_settings || (item_count > 0u && settings == NULL)) {
+        return H2_INTERNAL_ERROR;
+    }
+    for (item_index = 0u; item_index < item_count; item_index++) {
+        settings[item_index].id = h2_read_u16(payload + item_index * 6u);
+        settings[item_index].value = h2_read_u32(payload + item_index * 6u + 2u);
+    }
+    *settings_len = item_count;
+    return H2_OK;
+}
+
+int h2_frame_parse_window_update(const h2_frame_header *header, const uint8_t *payload, uint32_t *increment)
+{
+    int valid;
+
+    if (header == NULL || payload == NULL || increment == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_WINDOW_UPDATE) {
+        return H2_PROTOCOL_ERROR;
+    }
+    valid = h2_frame_validate_payload(header);
+    if (valid != H2_OK) {
+        return valid;
+    }
+    *increment = h2_read_u31(payload);
+    return *increment == 0u ? H2_PROTOCOL_ERROR : H2_OK;
+}
+
+int h2_frame_parse_ping(const h2_frame_header *header, const uint8_t *payload, uint8_t opaque[8])
+{
+    int valid;
+
+    if (header == NULL || payload == NULL || opaque == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_PING) {
+        return H2_PROTOCOL_ERROR;
+    }
+    valid = h2_frame_validate_payload(header);
+    if (valid != H2_OK) {
+        return valid;
+    }
+    memcpy(opaque, payload, 8u);
+    return H2_OK;
+}
+
+int h2_frame_parse_goaway(const h2_frame_header *header, const uint8_t *payload, h2_goaway_payload *out)
+{
+    int valid;
+
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_GOAWAY) {
+        return H2_PROTOCOL_ERROR;
+    }
+    valid = h2_frame_validate_payload(header);
+    if (valid != H2_OK) {
+        return valid;
+    }
+    out->last_stream_id = h2_read_u31(payload);
+    out->error_code = h2_read_u32(payload + 4u);
+    out->debug_data = payload + 8u;
+    out->debug_len = header->length - 8u;
+    return H2_OK;
+}
+
+int h2_frame_parse_rst_stream(const h2_frame_header *header, const uint8_t *payload, uint32_t *error_code)
+{
+    int valid;
+
+    if (header == NULL || payload == NULL || error_code == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_RST_STREAM) {
+        return H2_PROTOCOL_ERROR;
+    }
+    valid = h2_frame_validate_payload(header);
+    if (valid != H2_OK) {
+        return valid;
+    }
+    *error_code = h2_read_u32(payload);
+    return H2_OK;
+}
+
+int h2_frame_parse_continuation(const h2_frame_header *header, const uint8_t *payload, h2_continuation_payload *out)
+{
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_CONTINUATION || h2_frame_validate_payload(header) != H2_OK) {
+        return H2_PROTOCOL_ERROR;
+    }
+    out->header_block = payload;
+    out->header_block_len = header->length;
+    return H2_OK;
+}
+
+int h2_frame_parse_push_promise(const h2_frame_header *header, const uint8_t *payload, h2_push_promise_payload *out)
+{
+    size_t block_len;
+    size_t payload_pos;
+    uint8_t pad_len;
+
+    if (header == NULL || payload == NULL || out == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (header->type != H2_FRAME_PUSH_PROMISE || h2_frame_validate_payload(header) != H2_OK) {
+        return H2_PROTOCOL_ERROR;
+    }
+
+    block_len = header->length;
+    payload_pos = 0u;
+    pad_len = 0u;
+    if ((header->flags & H2_FLAG_PADDED) != 0u) {
+        pad_len = payload[0];
+        payload_pos++;
+        block_len--;
+        if ((size_t)pad_len > block_len) {
+            return H2_PROTOCOL_ERROR;
+        }
+        block_len -= pad_len;
+    }
+    if (block_len < 4u) {
+        return H2_FRAME_SIZE_ERROR;
+    }
+    out->promised_stream_id = h2_read_u31(payload + payload_pos);
+    out->header_block = payload + payload_pos + 4u;
+    out->header_block_len = block_len - 4u;
+    out->pad_len = pad_len;
+    return H2_OK;
+}
+
+static size_t h2_frame_encode_raw(uint8_t *wire, size_t cap, uint8_t type, uint8_t flags, uint32_t stream_id, const uint8_t *payload, size_t payload_len)
+{
+    h2_frame_header header;
+
+    if (wire == NULL || payload_len > H2_MAX_FRAME_SIZE || cap < H2_FRAME_HEADER_LEN + payload_len) {
+        return 0u;
+    }
+    if (payload_len > 0u && payload == NULL) {
+        return 0u;
+    }
+    header.length = (uint32_t)payload_len;
+    header.type = type;
+    header.flags = flags;
+    header.stream_id = stream_id;
+    if (h2_frame_write_header(wire, cap, &header) != H2_OK) {
+        return 0u;
+    }
+    if (payload_len > 0u) {
+        memcpy(wire + H2_FRAME_HEADER_LEN, payload, payload_len);
+    }
+    return H2_FRAME_HEADER_LEN + payload_len;
+}
+
+size_t h2_frame_encode_data(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *data, size_t data_len)
+{
+    if (stream_id == 0u) {
+        return 0u;
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_DATA, flags, stream_id, data, data_len);
+}
+
+size_t h2_frame_encode_headers(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *header_block, size_t header_block_len)
+{
+    if (stream_id == 0u) {
+        return 0u;
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_HEADERS, flags, stream_id, header_block, header_block_len);
+}
+
+size_t h2_frame_encode_priority(uint8_t *wire, size_t cap, uint32_t stream_id, const h2_priority_payload *priority)
+{
+    uint8_t payload[5];
+    uint32_t dependency;
+
+    if (priority == NULL || stream_id == 0u) {
+        return 0u;
+    }
+    dependency = priority->stream_dependency & 0x7fffffffu;
+    if (priority->exclusive) {
+        dependency |= 0x80000000u;
+    }
+    h2_write_u32(payload, dependency);
+    payload[4] = priority->weight;
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_PRIORITY, 0u, stream_id, payload, sizeof(payload));
+}
+
+size_t h2_frame_encode_rst_stream(uint8_t *wire, size_t cap, uint32_t stream_id, uint32_t error_code)
+{
+    uint8_t payload[4];
+
+    if (stream_id == 0u) {
+        return 0u;
+    }
+    h2_write_u32(payload, error_code);
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_RST_STREAM, 0u, stream_id, payload, sizeof(payload));
+}
+
+size_t h2_frame_encode_settings(uint8_t *wire, size_t cap, uint8_t flags, const h2_setting *settings, size_t settings_len)
+{
+    uint8_t payload[96];
+    size_t setting_index;
+
+    if ((flags & H2_FLAG_ACK) != 0u) {
+        return settings_len == 0u ? h2_frame_encode_raw(wire, cap, H2_FRAME_SETTINGS, H2_FLAG_ACK, 0u, NULL, 0u) : 0u;
+    }
+    if (settings_len > sizeof(payload) / 6u || (settings_len > 0u && settings == NULL)) {
+        return 0u;
+    }
+    for (setting_index = 0u; setting_index < settings_len; setting_index++) {
+        h2_write_u16(payload + setting_index * 6u, settings[setting_index].id);
+        h2_write_u32(payload + setting_index * 6u + 2u, settings[setting_index].value);
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_SETTINGS, flags, 0u, payload, settings_len * 6u);
+}
+
+size_t h2_frame_encode_push_promise(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, uint32_t promised_stream_id, const uint8_t *header_block, size_t header_block_len)
+{
+    uint8_t payload[H2_DEFAULT_MAX_FRAME_SIZE];
+
+    if (stream_id == 0u || header_block_len + 4u > sizeof(payload) || (header_block_len > 0u && header_block == NULL)) {
+        return 0u;
+    }
+    h2_write_u32(payload, promised_stream_id & 0x7fffffffu);
+    if (header_block_len > 0u) {
+        memcpy(payload + 4u, header_block, header_block_len);
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_PUSH_PROMISE, flags, stream_id, payload, header_block_len + 4u);
+}
+
+size_t h2_frame_encode_ping(uint8_t *wire, size_t cap, uint8_t flags, const uint8_t opaque[8])
+{
+    if (opaque == NULL) {
+        return 0u;
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_PING, flags, 0u, opaque, 8u);
+}
+
+size_t h2_frame_encode_goaway(uint8_t *wire, size_t cap, uint32_t last_stream_id, uint32_t error_code, const uint8_t *debug_data, size_t debug_len)
+{
+    uint8_t payload[H2_DEFAULT_MAX_FRAME_SIZE];
+
+    if (debug_len + 8u > sizeof(payload) || (debug_len > 0u && debug_data == NULL)) {
+        return 0u;
+    }
+    h2_write_u32(payload, last_stream_id & 0x7fffffffu);
+    h2_write_u32(payload + 4u, error_code);
+    if (debug_len > 0u) {
+        memcpy(payload + 8u, debug_data, debug_len);
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_GOAWAY, 0u, 0u, payload, debug_len + 8u);
+}
+
+size_t h2_frame_encode_window_update(uint8_t *wire, size_t cap, uint32_t stream_id, uint32_t increment)
+{
+    uint8_t payload[4];
+
+    if (increment == 0u || (increment & 0x80000000u) != 0u) {
+        return 0u;
+    }
+    h2_write_u32(payload, increment);
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_WINDOW_UPDATE, 0u, stream_id, payload, sizeof(payload));
+}
+
+size_t h2_frame_encode_continuation(uint8_t *wire, size_t cap, uint32_t stream_id, uint8_t flags, const uint8_t *header_block, size_t header_block_len)
+{
+    if (stream_id == 0u) {
+        return 0u;
+    }
+    return h2_frame_encode_raw(wire, cap, H2_FRAME_CONTINUATION, flags, stream_id, header_block, header_block_len);
+}

--- a/phase1/http2/src/hpack.c
+++ b/phase1/http2/src/hpack.c
@@ -1,0 +1,334 @@
+#include "http2/hpack.h"
+
+#include "http2/hpack_static.h"
+
+#include <limits.h>
+#include <stdbool.h>
+#include <string.h>
+
+static int h2_copy_text(char *dst, size_t dst_cap, const char *src)
+{
+    size_t src_len;
+
+    if (dst == NULL || src == NULL || dst_cap == 0u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    src_len = strlen(src);
+    if (src_len >= dst_cap) {
+        return H2_COMPRESSION_ERROR;
+    }
+    memcpy(dst, src, src_len + 1u);
+    return H2_OK;
+}
+
+int h2_hpack_decode_integer(const uint8_t *wire, size_t wire_len, uint8_t prefix_bits, uint32_t *value, size_t *used)
+{
+    uint32_t prefix_max;
+    uint32_t result;
+    uint32_t shift;
+    size_t pos;
+
+    if (wire == NULL || value == NULL || used == NULL || wire_len == 0u || prefix_bits == 0u || prefix_bits > 8u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    prefix_max = (1u << prefix_bits) - 1u;
+    result = (uint32_t)(wire[0] & (uint8_t)prefix_max);
+    if (result < prefix_max) {
+        *value = result;
+        *used = 1u;
+        return H2_OK;
+    }
+
+    shift = 0u;
+    pos = 1u;
+    while (pos < wire_len) {
+        uint8_t byte;
+
+        byte = wire[pos];
+        if (shift >= 28u && (byte & 0x7fu) > 15u) {
+            return H2_COMPRESSION_ERROR;
+        }
+        result += ((uint32_t)(byte & 0x7fu)) << shift;
+        pos++;
+        if ((byte & 0x80u) == 0u) {
+            *value = result;
+            *used = pos;
+            return H2_OK;
+        }
+        shift += 7u;
+    }
+    return H2_COMPRESSION_ERROR;
+}
+
+size_t h2_hpack_encode_integer(uint8_t *wire, size_t cap, uint8_t prefix_bits, uint8_t high_bits, uint32_t value)
+{
+    uint32_t prefix_max;
+    size_t pos;
+
+    if (wire == NULL || cap == 0u || prefix_bits == 0u || prefix_bits > 8u) {
+        return 0u;
+    }
+    prefix_max = (1u << prefix_bits) - 1u;
+    if (value < prefix_max) {
+        wire[0] = (uint8_t)(high_bits | (uint8_t)value);
+        return 1u;
+    }
+
+    wire[0] = (uint8_t)(high_bits | (uint8_t)prefix_max);
+    value -= prefix_max;
+    pos = 1u;
+    while (value >= 128u) {
+        if (pos >= cap) {
+            return 0u;
+        }
+        wire[pos] = (uint8_t)((value & 0x7fu) | 0x80u);
+        value >>= 7u;
+        pos++;
+    }
+    if (pos >= cap) {
+        return 0u;
+    }
+    wire[pos] = (uint8_t)value;
+    return pos + 1u;
+}
+
+size_t h2_hpack_encode_indexed(uint8_t *wire, size_t cap, uint32_t static_index)
+{
+    if (h2_hpack_static_get(static_index) == NULL) {
+        return 0u;
+    }
+    return h2_hpack_encode_integer(wire, cap, 7u, 0x80u, static_index);
+}
+
+size_t h2_hpack_encode_string(uint8_t *wire, size_t cap, const char *text)
+{
+    size_t text_len;
+    size_t prefix_len;
+
+    if (wire == NULL || text == NULL) {
+        return 0u;
+    }
+    text_len = strlen(text);
+    if (text_len > UINT32_MAX) {
+        return 0u;
+    }
+    prefix_len = h2_hpack_encode_integer(wire, cap, 7u, 0x00u, (uint32_t)text_len);
+    if (prefix_len == 0u || prefix_len + text_len > cap) {
+        return 0u;
+    }
+    memcpy(wire + prefix_len, text, text_len);
+    return prefix_len + text_len;
+}
+
+size_t h2_hpack_encode_literal_new_name(uint8_t *wire, size_t cap, const char *name, const char *value)
+{
+    size_t pos;
+    size_t chunk_len;
+
+    if (wire == NULL || cap == 0u || name == NULL || value == NULL) {
+        return 0u;
+    }
+    wire[0] = 0x00u;
+    pos = 1u;
+    chunk_len = h2_hpack_encode_string(wire + pos, cap - pos, name);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_string(wire + pos, cap - pos, value);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    return pos + chunk_len;
+}
+
+static int h2_hpack_decode_string(const uint8_t *wire, size_t wire_len, char *out, size_t out_cap, size_t *used)
+{
+    uint32_t value_len;
+    size_t prefix_len;
+
+    if (wire == NULL || out == NULL || used == NULL || out_cap == 0u || wire_len == 0u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if ((wire[0] & 0x80u) != 0u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if (h2_hpack_decode_integer(wire, wire_len, 7u, &value_len, &prefix_len) != H2_OK) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if (prefix_len + value_len > wire_len || (size_t)value_len >= out_cap) {
+        return H2_COMPRESSION_ERROR;
+    }
+    memcpy(out, wire + prefix_len, value_len);
+    out[value_len] = '\0';
+    *used = prefix_len + value_len;
+    return H2_OK;
+}
+
+static int h2_hpack_skip_string(const uint8_t *wire, size_t wire_len, size_t *used)
+{
+    uint32_t value_len;
+    size_t prefix_len;
+
+    if (wire == NULL || used == NULL || wire_len == 0u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if (h2_hpack_decode_integer(wire, wire_len, 7u, &value_len, &prefix_len) != H2_OK) {
+        return H2_COMPRESSION_ERROR;
+    }
+    if (prefix_len + value_len > wire_len) {
+        return H2_COMPRESSION_ERROR;
+    }
+    *used = prefix_len + value_len;
+    return H2_OK;
+}
+
+static int h2_hpack_decode_indexed_literal_name(const uint8_t *wire, size_t wire_len, uint8_t prefix_bits, char *name, size_t name_cap, size_t *pos)
+{
+    uint32_t name_index;
+    size_t used;
+
+    if (h2_hpack_decode_integer(wire + *pos, wire_len - *pos, prefix_bits, &name_index, &used) != H2_OK) {
+        return H2_COMPRESSION_ERROR;
+    }
+    *pos += used;
+    if (name_index == 0u) {
+        if (h2_hpack_decode_string(wire + *pos, wire_len - *pos, name, name_cap, &used) != H2_OK) {
+            return H2_COMPRESSION_ERROR;
+        }
+        *pos += used;
+        return H2_OK;
+    }
+    if (h2_hpack_static_get(name_index) == NULL) {
+        return H2_COMPRESSION_ERROR;
+    }
+    return h2_copy_text(name, name_cap, h2_hpack_static_get(name_index)->name);
+}
+
+int h2_hpack_decode_headers(const uint8_t *wire, size_t wire_len, h2_header_field *fields, size_t field_cap, size_t *field_len)
+{
+    size_t pos;
+    size_t count;
+
+    if (wire == NULL || fields == NULL || field_len == NULL) {
+        return H2_COMPRESSION_ERROR;
+    }
+    pos = 0u;
+    count = 0u;
+    while (pos < wire_len) {
+        const h2_hpack_static_entry *entry;
+        uint32_t index;
+        size_t used;
+
+        if (count >= field_cap) {
+            return H2_COMPRESSION_ERROR;
+        }
+        if ((wire[pos] & 0x80u) != 0u) {
+            if (h2_hpack_decode_integer(wire + pos, wire_len - pos, 7u, &index, &used) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            entry = h2_hpack_static_get(index);
+            if (entry == NULL || h2_copy_text(fields[count].name, sizeof(fields[count].name), entry->name) != H2_OK || h2_copy_text(fields[count].value, sizeof(fields[count].value), entry->value) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            pos += used;
+            count++;
+            continue;
+        }
+        if ((wire[pos] & 0xe0u) == 0x20u) {
+            if (h2_hpack_decode_integer(wire + pos, wire_len - pos, 5u, &index, &used) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            pos += used;
+            continue;
+        }
+        if ((wire[pos] & 0x40u) != 0u) {
+            if (h2_hpack_decode_indexed_literal_name(wire, wire_len, 6u, fields[count].name, sizeof(fields[count].name), &pos) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+        } else {
+            if (h2_hpack_decode_indexed_literal_name(wire, wire_len, 4u, fields[count].name, sizeof(fields[count].name), &pos) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+        }
+        if (h2_hpack_decode_string(wire + pos, wire_len - pos, fields[count].value, sizeof(fields[count].value), &used) != H2_OK) {
+            return H2_COMPRESSION_ERROR;
+        }
+        pos += used;
+        count++;
+    }
+    *field_len = count;
+    return H2_OK;
+}
+
+static int h2_maybe_copy_path(const char *name, const char *value, char *path, size_t path_cap)
+{
+    if (strcmp(name, ":path") == 0) {
+        return h2_copy_text(path, path_cap, value);
+    }
+    return H2_OK;
+}
+
+int h2_hpack_extract_path(const uint8_t *wire, size_t wire_len, char *path, size_t path_cap)
+{
+    size_t pos;
+
+    if (wire == NULL || path == NULL || path_cap == 0u) {
+        return H2_COMPRESSION_ERROR;
+    }
+    path[0] = '\0';
+    pos = 0u;
+    while (pos < wire_len) {
+        const h2_hpack_static_entry *entry;
+        uint32_t index;
+        size_t used;
+        char name[64];
+        char value[256];
+
+        if ((wire[pos] & 0x80u) != 0u) {
+            if (h2_hpack_decode_integer(wire + pos, wire_len - pos, 7u, &index, &used) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            entry = h2_hpack_static_get(index);
+            if (entry == NULL) {
+                return H2_COMPRESSION_ERROR;
+            }
+            if (h2_maybe_copy_path(entry->name, entry->value, path, path_cap) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            pos += used;
+            continue;
+        }
+        if ((wire[pos] & 0xe0u) == 0x20u) {
+            if (h2_hpack_decode_integer(wire + pos, wire_len - pos, 5u, &index, &used) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            pos += used;
+            continue;
+        }
+        if ((wire[pos] & 0x40u) != 0u) {
+            if (h2_hpack_decode_indexed_literal_name(wire, wire_len, 6u, name, sizeof(name), &pos) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+        } else {
+            if (h2_hpack_decode_indexed_literal_name(wire, wire_len, 4u, name, sizeof(name), &pos) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+        }
+        if (strcmp(name, ":path") == 0) {
+            if (h2_hpack_decode_string(wire + pos, wire_len - pos, value, sizeof(value), &used) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+            if (h2_copy_text(path, path_cap, value) != H2_OK) {
+                return H2_COMPRESSION_ERROR;
+            }
+        } else if (h2_hpack_skip_string(wire + pos, wire_len - pos, &used) != H2_OK) {
+            return H2_COMPRESSION_ERROR;
+        }
+        pos += used;
+    }
+    if (path[0] == '\0') {
+        return H2_PROTOCOL_ERROR;
+    }
+    return H2_OK;
+}

--- a/phase1/http2/src/hpack_static.c
+++ b/phase1/http2/src/hpack_static.c
@@ -1,0 +1,76 @@
+#include "http2/hpack_static.h"
+
+#include <stddef.h>
+
+static const h2_hpack_static_entry h2_static_table[H2_HPACK_STATIC_TABLE_LEN + 1u] = {
+    { NULL, NULL },
+    { ":authority", "" },
+    { ":method", "GET" },
+    { ":method", "POST" },
+    { ":path", "/" },
+    { ":path", "/index.html" },
+    { ":scheme", "http" },
+    { ":scheme", "https" },
+    { ":status", "200" },
+    { ":status", "204" },
+    { ":status", "206" },
+    { ":status", "304" },
+    { ":status", "400" },
+    { ":status", "404" },
+    { ":status", "500" },
+    { "accept-charset", "" },
+    { "accept-encoding", "gzip, deflate" },
+    { "accept-language", "" },
+    { "accept-ranges", "" },
+    { "accept", "" },
+    { "access-control-allow-origin", "" },
+    { "age", "" },
+    { "allow", "" },
+    { "authorization", "" },
+    { "cache-control", "" },
+    { "content-disposition", "" },
+    { "content-encoding", "" },
+    { "content-language", "" },
+    { "content-length", "" },
+    { "content-location", "" },
+    { "content-range", "" },
+    { "content-type", "" },
+    { "cookie", "" },
+    { "date", "" },
+    { "etag", "" },
+    { "expect", "" },
+    { "expires", "" },
+    { "from", "" },
+    { "host", "" },
+    { "if-match", "" },
+    { "if-modified-since", "" },
+    { "if-none-match", "" },
+    { "if-range", "" },
+    { "if-unmodified-since", "" },
+    { "last-modified", "" },
+    { "link", "" },
+    { "location", "" },
+    { "max-forwards", "" },
+    { "proxy-authenticate", "" },
+    { "proxy-authorization", "" },
+    { "range", "" },
+    { "referer", "" },
+    { "refresh", "" },
+    { "retry-after", "" },
+    { "server", "" },
+    { "set-cookie", "" },
+    { "strict-transport-security", "" },
+    { "transfer-encoding", "" },
+    { "user-agent", "" },
+    { "vary", "" },
+    { "via", "" },
+    { "www-authenticate", "" }
+};
+
+const h2_hpack_static_entry *h2_hpack_static_get(uint32_t index)
+{
+    if (index == 0u || index > H2_HPACK_STATIC_TABLE_LEN) {
+        return NULL;
+    }
+    return &h2_static_table[index];
+}

--- a/phase1/http2/src/io_epoll.c
+++ b/phase1/http2/src/io_epoll.c
@@ -1,0 +1,93 @@
+#include "http2/io.h"
+
+#if defined(HTTP2_BACKEND_EPOLL)
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+const char *h2_io_backend_name(void)
+{
+    return "epoll";
+}
+
+int h2_io_init(h2_io *io)
+{
+    if (io == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    io->fd = epoll_create1(EPOLL_CLOEXEC);
+    io->state = NULL;
+    return io->fd >= 0 ? 0 : -1;
+}
+
+static int h2_io_ctl(h2_io *io, int op, int fd, uint32_t events)
+{
+    struct epoll_event event;
+
+    memset(&event, 0, sizeof(event));
+    event.events = events;
+    event.data.fd = fd;
+    return epoll_ctl(io->fd, op, fd, &event);
+}
+
+int h2_io_add_listener(h2_io *io, int fd)
+{
+    return h2_io_ctl(io, EPOLL_CTL_ADD, fd, EPOLLIN | EPOLLRDHUP);
+}
+
+int h2_io_add_connection(h2_io *io, int fd)
+{
+    return h2_io_ctl(io, EPOLL_CTL_ADD, fd, EPOLLIN | EPOLLRDHUP);
+}
+
+int h2_io_mod_connection(h2_io *io, int fd, bool want_write)
+{
+    uint32_t events;
+
+    events = EPOLLIN | EPOLLRDHUP;
+    if (want_write) {
+        events |= EPOLLOUT;
+    }
+    return h2_io_ctl(io, EPOLL_CTL_MOD, fd, events);
+}
+
+int h2_io_remove(h2_io *io, int fd)
+{
+    (void)epoll_ctl(io->fd, EPOLL_CTL_DEL, fd, NULL);
+    return 0;
+}
+
+int h2_io_wait(h2_io *io, h2_event *events, size_t event_cap, int timeout_ms)
+{
+    struct epoll_event kernel_events[64];
+    int count;
+    int pos;
+
+    if (event_cap > sizeof(kernel_events) / sizeof(kernel_events[0])) {
+        event_cap = sizeof(kernel_events) / sizeof(kernel_events[0]);
+    }
+    count = epoll_wait(io->fd, kernel_events, (int)event_cap, timeout_ms);
+    if (count < 0) {
+        return errno == EINTR ? 0 : -1;
+    }
+    for (pos = 0; pos < count; pos++) {
+        events[pos].fd = kernel_events[pos].data.fd;
+        events[pos].readable = (kernel_events[pos].events & EPOLLIN) != 0u;
+        events[pos].writable = (kernel_events[pos].events & EPOLLOUT) != 0u;
+        events[pos].closed = (kernel_events[pos].events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP)) != 0u;
+    }
+    return count;
+}
+
+void h2_io_close(h2_io *io)
+{
+    if (io != NULL && io->fd >= 0) {
+        close(io->fd);
+        io->fd = -1;
+    }
+}
+#endif

--- a/phase1/http2/src/io_kqueue.c
+++ b/phase1/http2/src/io_kqueue.c
@@ -1,0 +1,96 @@
+#include "http2/io.h"
+
+#if defined(HTTP2_BACKEND_KQUEUE)
+
+#include <errno.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+const char *h2_io_backend_name(void)
+{
+    return "kqueue";
+}
+
+int h2_io_init(h2_io *io)
+{
+    if (io == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    io->fd = kqueue();
+    io->state = NULL;
+    return io->fd >= 0 ? 0 : -1;
+}
+
+static int h2_io_kevent(int kq, int fd, int16_t filter, uint16_t flags)
+{
+    struct kevent change;
+
+    EV_SET(&change, (uintptr_t)fd, filter, flags, 0u, 0, NULL);
+    return kevent(kq, &change, 1, NULL, 0, NULL);
+}
+
+int h2_io_add_listener(h2_io *io, int fd)
+{
+    return h2_io_kevent(io->fd, fd, EVFILT_READ, EV_ADD | EV_ENABLE);
+}
+
+int h2_io_add_connection(h2_io *io, int fd)
+{
+    if (h2_io_kevent(io->fd, fd, EVFILT_READ, EV_ADD | EV_ENABLE) != 0) {
+        return -1;
+    }
+    return h2_io_kevent(io->fd, fd, EVFILT_WRITE, EV_ADD | EV_DISABLE);
+}
+
+int h2_io_mod_connection(h2_io *io, int fd, bool want_write)
+{
+    return h2_io_kevent(io->fd, fd, EVFILT_WRITE, want_write ? EV_ENABLE : EV_DISABLE);
+}
+
+int h2_io_remove(h2_io *io, int fd)
+{
+    (void)h2_io_kevent(io->fd, fd, EVFILT_READ, EV_DELETE);
+    (void)h2_io_kevent(io->fd, fd, EVFILT_WRITE, EV_DELETE);
+    return 0;
+}
+
+int h2_io_wait(h2_io *io, h2_event *events, size_t event_cap, int timeout_ms)
+{
+    struct kevent kernel_events[64];
+    struct timespec timeout;
+    struct timespec *timeout_ptr;
+    int count;
+    int pos;
+
+    if (event_cap > sizeof(kernel_events) / sizeof(kernel_events[0])) {
+        event_cap = sizeof(kernel_events) / sizeof(kernel_events[0]);
+    }
+    timeout_ptr = NULL;
+    if (timeout_ms >= 0) {
+        timeout.tv_sec = timeout_ms / 1000;
+        timeout.tv_nsec = (long)(timeout_ms % 1000) * 1000000L;
+        timeout_ptr = &timeout;
+    }
+    count = kevent(io->fd, NULL, 0, kernel_events, (int)event_cap, timeout_ptr);
+    if (count < 0) {
+        return errno == EINTR ? 0 : -1;
+    }
+    for (pos = 0; pos < count; pos++) {
+        events[pos].fd = (int)kernel_events[pos].ident;
+        events[pos].readable = kernel_events[pos].filter == EVFILT_READ;
+        events[pos].writable = kernel_events[pos].filter == EVFILT_WRITE;
+        events[pos].closed = (kernel_events[pos].flags & (EV_EOF | EV_ERROR)) != 0;
+    }
+    return count;
+}
+
+void h2_io_close(h2_io *io)
+{
+    if (io != NULL && io->fd >= 0) {
+        close(io->fd);
+        io->fd = -1;
+    }
+}
+#endif

--- a/phase1/http2/src/io_uring.c
+++ b/phase1/http2/src/io_uring.c
@@ -1,0 +1,293 @@
+#include "http2/io.h"
+
+#if defined(HTTP2_BACKEND_IO_URING)
+
+#include <errno.h>
+#include <linux/io_uring.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define H2_URING_ENTRIES 256u
+#define H2_URING_MAX_FDS 4096u
+
+typedef struct h2_uring_fd_state {
+    bool used;
+    bool active;
+    uint32_t events;
+} h2_uring_fd_state;
+
+typedef struct h2_uring_state {
+    int ring_fd;
+    void *sq_ring_ptr;
+    void *cq_ring_ptr;
+    void *sqes_ptr;
+    size_t sq_ring_size;
+    size_t cq_ring_size;
+    size_t sqes_size;
+    unsigned *sq_head;
+    unsigned *sq_tail;
+    unsigned *sq_ring_mask;
+    unsigned *sq_ring_entries;
+    unsigned *sq_array;
+    struct io_uring_sqe *sqes;
+    unsigned *cq_head;
+    unsigned *cq_tail;
+    unsigned *cq_ring_mask;
+    struct io_uring_cqe *cqes;
+    h2_uring_fd_state fds[H2_URING_MAX_FDS];
+} h2_uring_state;
+
+const char *h2_io_backend_name(void)
+{
+    return "io_uring";
+}
+
+static int h2_uring_enter(int fd, unsigned to_submit, unsigned min_complete, unsigned flags)
+{
+    return (int)syscall(__NR_io_uring_enter, fd, to_submit, min_complete, flags, NULL, 0);
+}
+
+static void *h2_uring_offset(void *base, unsigned offset)
+{
+    return (uint8_t *)base + offset;
+}
+
+static int h2_uring_map(h2_uring_state *state, const struct io_uring_params *params)
+{
+    state->sq_ring_size = params->sq_off.array + params->sq_entries * sizeof(unsigned);
+    state->cq_ring_size = params->cq_off.cqes + params->cq_entries * sizeof(struct io_uring_cqe);
+    if ((params->features & IORING_FEAT_SINGLE_MMAP) != 0u) {
+        size_t ring_size;
+
+        ring_size = state->sq_ring_size > state->cq_ring_size ? state->sq_ring_size : state->cq_ring_size;
+        state->sq_ring_size = ring_size;
+        state->cq_ring_size = ring_size;
+        state->sq_ring_ptr = mmap(NULL, ring_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, state->ring_fd, IORING_OFF_SQ_RING);
+        if (state->sq_ring_ptr == MAP_FAILED) {
+            return -1;
+        }
+        state->cq_ring_ptr = state->sq_ring_ptr;
+    } else {
+        state->sq_ring_ptr = mmap(NULL, state->sq_ring_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, state->ring_fd, IORING_OFF_SQ_RING);
+        if (state->sq_ring_ptr == MAP_FAILED) {
+            return -1;
+        }
+        state->cq_ring_ptr = mmap(NULL, state->cq_ring_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, state->ring_fd, IORING_OFF_CQ_RING);
+        if (state->cq_ring_ptr == MAP_FAILED) {
+            return -1;
+        }
+    }
+    state->sqes_size = params->sq_entries * sizeof(struct io_uring_sqe);
+    state->sqes_ptr = mmap(NULL, state->sqes_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, state->ring_fd, IORING_OFF_SQES);
+    if (state->sqes_ptr == MAP_FAILED) {
+        return -1;
+    }
+    state->sq_head = h2_uring_offset(state->sq_ring_ptr, params->sq_off.head);
+    state->sq_tail = h2_uring_offset(state->sq_ring_ptr, params->sq_off.tail);
+    state->sq_ring_mask = h2_uring_offset(state->sq_ring_ptr, params->sq_off.ring_mask);
+    state->sq_ring_entries = h2_uring_offset(state->sq_ring_ptr, params->sq_off.ring_entries);
+    state->sq_array = h2_uring_offset(state->sq_ring_ptr, params->sq_off.array);
+    state->sqes = state->sqes_ptr;
+    state->cq_head = h2_uring_offset(state->cq_ring_ptr, params->cq_off.head);
+    state->cq_tail = h2_uring_offset(state->cq_ring_ptr, params->cq_off.tail);
+    state->cq_ring_mask = h2_uring_offset(state->cq_ring_ptr, params->cq_off.ring_mask);
+    state->cqes = h2_uring_offset(state->cq_ring_ptr, params->cq_off.cqes);
+    return 0;
+}
+
+int h2_io_init(h2_io *io)
+{
+    struct io_uring_params params;
+    h2_uring_state *state;
+
+    if (io == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    state = calloc(1u, sizeof(*state));
+    if (state == NULL) {
+        return -1;
+    }
+    memset(&params, 0, sizeof(params));
+    state->ring_fd = (int)syscall(__NR_io_uring_setup, H2_URING_ENTRIES, &params);
+    if (state->ring_fd < 0) {
+        free(state);
+        return -1;
+    }
+    if (h2_uring_map(state, &params) != 0) {
+        h2_io tmp;
+
+        tmp.fd = -1;
+        tmp.state = state;
+        h2_io_close(&tmp);
+        return -1;
+    }
+    io->fd = state->ring_fd;
+    io->state = state;
+    return 0;
+}
+
+static int h2_uring_set_fd(h2_io *io, int fd, bool used, uint32_t events)
+{
+    h2_uring_state *state;
+
+    if (fd < 0 || fd >= (int)H2_URING_MAX_FDS) {
+        errno = EMFILE;
+        return -1;
+    }
+    state = io->state;
+    state->fds[fd].used = used;
+    state->fds[fd].events = events;
+    if (!used) {
+        state->fds[fd].active = false;
+    }
+    return 0;
+}
+
+int h2_io_add_listener(h2_io *io, int fd)
+{
+    return h2_uring_set_fd(io, fd, true, POLLIN | POLLERR | POLLHUP);
+}
+
+int h2_io_add_connection(h2_io *io, int fd)
+{
+    return h2_uring_set_fd(io, fd, true, POLLIN | POLLRDHUP | POLLERR | POLLHUP);
+}
+
+int h2_io_mod_connection(h2_io *io, int fd, bool want_write)
+{
+    uint32_t events;
+
+    events = POLLIN | POLLRDHUP | POLLERR | POLLHUP;
+    if (want_write) {
+        events |= POLLOUT;
+    }
+    return h2_uring_set_fd(io, fd, true, events);
+}
+
+int h2_io_remove(h2_io *io, int fd)
+{
+    return h2_uring_set_fd(io, fd, false, 0u);
+}
+
+static struct io_uring_sqe *h2_uring_get_sqe(h2_uring_state *state)
+{
+    unsigned head;
+    unsigned tail;
+    unsigned index;
+
+    head = *state->sq_head;
+    tail = *state->sq_tail;
+    if (tail - head >= *state->sq_ring_entries) {
+        return NULL;
+    }
+    index = tail & *state->sq_ring_mask;
+    state->sq_array[index] = index;
+    *state->sq_tail = tail + 1u;
+    return &state->sqes[index];
+}
+
+static int h2_uring_submit_missing(h2_uring_state *state)
+{
+    unsigned submitted;
+    int fd;
+
+    submitted = 0u;
+    for (fd = 0; fd < (int)H2_URING_MAX_FDS; fd++) {
+        struct io_uring_sqe *sqe;
+
+        if (!state->fds[fd].used || state->fds[fd].active) {
+            continue;
+        }
+        sqe = h2_uring_get_sqe(state);
+        if (sqe == NULL) {
+            break;
+        }
+        memset(sqe, 0, sizeof(*sqe));
+        sqe->opcode = IORING_OP_POLL_ADD;
+        sqe->fd = fd;
+        sqe->poll_events = (uint16_t)state->fds[fd].events;
+        sqe->user_data = (uint64_t)(uint32_t)fd;
+        state->fds[fd].active = true;
+        submitted++;
+    }
+    if (submitted == 0u) {
+        return 0;
+    }
+    return h2_uring_enter(state->ring_fd, submitted, 0u, 0u) < 0 ? -1 : 0;
+}
+
+int h2_io_wait(h2_io *io, h2_event *events, size_t event_cap, int timeout_ms)
+{
+    h2_uring_state *state;
+    unsigned head;
+    unsigned tail;
+    int out_count;
+
+    (void)timeout_ms;
+    state = io->state;
+    if (h2_uring_submit_missing(state) != 0) {
+        return -1;
+    }
+    if (*state->cq_head == *state->cq_tail) {
+        if (h2_uring_enter(state->ring_fd, 0u, 1u, IORING_ENTER_GETEVENTS) < 0) {
+            return errno == EINTR ? 0 : -1;
+        }
+    }
+    out_count = 0;
+    head = *state->cq_head;
+    tail = *state->cq_tail;
+    while (head != tail && (size_t)out_count < event_cap) {
+        struct io_uring_cqe *cqe;
+        int fd;
+        int result;
+
+        cqe = &state->cqes[head & *state->cq_ring_mask];
+        fd = (int)cqe->user_data;
+        result = cqe->res;
+        if (fd >= 0 && fd < (int)H2_URING_MAX_FDS) {
+            state->fds[fd].active = false;
+            if (state->fds[fd].used) {
+                events[out_count].fd = fd;
+                events[out_count].readable = result > 0 && ((uint32_t)result & POLLIN) != 0u;
+                events[out_count].writable = result > 0 && ((uint32_t)result & POLLOUT) != 0u;
+                events[out_count].closed = result < 0 || (result > 0 && ((uint32_t)result & (POLLERR | POLLHUP | POLLRDHUP)) != 0u);
+                out_count++;
+            }
+        }
+        head++;
+    }
+    *state->cq_head = head;
+    return out_count;
+}
+
+void h2_io_close(h2_io *io)
+{
+    h2_uring_state *state;
+
+    if (io == NULL || io->state == NULL) {
+        return;
+    }
+    state = io->state;
+    if (state->sqes_ptr != NULL && state->sqes_ptr != MAP_FAILED) {
+        munmap(state->sqes_ptr, state->sqes_size);
+    }
+    if (state->sq_ring_ptr != NULL && state->sq_ring_ptr != MAP_FAILED) {
+        munmap(state->sq_ring_ptr, state->sq_ring_size);
+    }
+    if (state->cq_ring_ptr != NULL && state->cq_ring_ptr != MAP_FAILED && state->cq_ring_ptr != state->sq_ring_ptr) {
+        munmap(state->cq_ring_ptr, state->cq_ring_size);
+    }
+    if (state->ring_fd >= 0) {
+        close(state->ring_fd);
+    }
+    free(state);
+    io->fd = -1;
+    io->state = NULL;
+}
+#endif

--- a/phase1/http2/src/main.c
+++ b/phase1/http2/src/main.c
@@ -1,0 +1,83 @@
+#include "http2/server.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void h2_usage(const char *argv0)
+{
+    fprintf(stderr, "usage: %s [--host 127.0.0.1] [--port 8080] [--ready-file path] [--max-connections n]\n", argv0);
+}
+
+static int h2_parse_u16(const char *text, uint16_t *out)
+{
+    char *end;
+    unsigned long value;
+
+    errno = 0;
+    value = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || value > 65535ul) {
+        return -1;
+    }
+    *out = (uint16_t)value;
+    return 0;
+}
+
+static int h2_parse_unsigned(const char *text, unsigned *out)
+{
+    char *end;
+    unsigned long value;
+
+    errno = 0;
+    value = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        return -1;
+    }
+    *out = (unsigned)value;
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    h2_server_config config;
+    int pos;
+
+    config.host = "127.0.0.1";
+    config.port = 8080u;
+    config.ready_file = NULL;
+    config.max_connections = 0u;
+    pos = 1;
+    while (pos < argc) {
+        if (strcmp(argv[pos], "--host") == 0 && pos + 1 < argc) {
+            config.host = argv[pos + 1];
+            pos += 2;
+        } else if (strcmp(argv[pos], "--port") == 0 && pos + 1 < argc) {
+            if (h2_parse_u16(argv[pos + 1], &config.port) != 0) {
+                h2_usage(argv[0]);
+                return 2;
+            }
+            pos += 2;
+        } else if (strcmp(argv[pos], "--ready-file") == 0 && pos + 1 < argc) {
+            config.ready_file = argv[pos + 1];
+            pos += 2;
+        } else if (strcmp(argv[pos], "--max-connections") == 0 && pos + 1 < argc) {
+            if (h2_parse_unsigned(argv[pos + 1], &config.max_connections) != 0) {
+                h2_usage(argv[0]);
+                return 2;
+            }
+            pos += 2;
+        } else if (strcmp(argv[pos], "--help") == 0) {
+            h2_usage(argv[0]);
+            return 0;
+        } else {
+            h2_usage(argv[0]);
+            return 2;
+        }
+    }
+    if (h2_server_run(&config) != 0) {
+        perror("h2d");
+        return 1;
+    }
+    return 0;
+}

--- a/phase1/http2/src/server.c
+++ b/phase1/http2/src/server.c
@@ -1,0 +1,327 @@
+#include "http2/server.h"
+
+#include "http2/connection.h"
+#include "http2/io.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define H2_SERVER_MAX_CLIENTS 128u
+
+typedef struct h2_client {
+    int fd;
+    bool used;
+    h2_connection conn;
+} h2_client;
+
+static int h2_set_nonblock(int fd)
+{
+    int flags;
+
+    flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        return -1;
+    }
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static int h2_create_listener(const h2_server_config *config, uint16_t *bound_port)
+{
+    struct sockaddr_in addr;
+    socklen_t addr_len;
+    int fd;
+    int yes;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    yes = 1;
+    (void)setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+#ifdef SO_NOSIGPIPE
+    (void)setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &yes, sizeof(yes));
+#endif
+    if (h2_set_nonblock(fd) != 0) {
+        close(fd);
+        return -1;
+    }
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(config->port);
+    if (inet_pton(AF_INET, config->host, &addr.sin_addr) != 1) {
+        close(fd);
+        errno = EINVAL;
+        return -1;
+    }
+    if (bind(fd, (const struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        close(fd);
+        return -1;
+    }
+    if (listen(fd, 128) != 0) {
+        close(fd);
+        return -1;
+    }
+    addr_len = sizeof(addr);
+    if (getsockname(fd, (struct sockaddr *)&addr, &addr_len) != 0) {
+        close(fd);
+        return -1;
+    }
+    *bound_port = ntohs(addr.sin_port);
+    return fd;
+}
+
+static int h2_write_ready_file(const char *path, uint16_t port)
+{
+    FILE *file;
+
+    if (path == NULL) {
+        return 0;
+    }
+    file = fopen(path, "w");
+    if (file == NULL) {
+        return -1;
+    }
+    fprintf(file, "%u\n", (unsigned)port);
+    if (fclose(file) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static h2_client *h2_find_client(h2_client *clients, int fd)
+{
+    size_t pos;
+
+    for (pos = 0u; pos < H2_SERVER_MAX_CLIENTS; pos++) {
+        if (clients[pos].used && clients[pos].fd == fd) {
+            return &clients[pos];
+        }
+    }
+    return NULL;
+}
+
+static h2_client *h2_alloc_client(h2_client *clients, int fd)
+{
+    size_t pos;
+
+    for (pos = 0u; pos < H2_SERVER_MAX_CLIENTS; pos++) {
+        if (!clients[pos].used) {
+            clients[pos].fd = fd;
+            clients[pos].used = true;
+            h2_connection_init(&clients[pos].conn);
+            return &clients[pos];
+        }
+    }
+    return NULL;
+}
+
+static unsigned h2_active_client_count(const h2_client *clients)
+{
+    unsigned count;
+    size_t pos;
+
+    count = 0u;
+    for (pos = 0u; pos < H2_SERVER_MAX_CLIENTS; pos++) {
+        if (clients[pos].used) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static void h2_close_client(h2_io *io, h2_client *client)
+{
+    if (client == NULL || !client->used) {
+        return;
+    }
+    (void)h2_io_remove(io, client->fd);
+    close(client->fd);
+    memset(client, 0, sizeof(*client));
+    client->fd = -1;
+}
+
+static int h2_flush_client(h2_client *client)
+{
+    while (h2_connection_wants_write(&client->conn)) {
+        ssize_t written;
+
+        written = write(client->fd, h2_connection_output(&client->conn), h2_connection_output_len(&client->conn));
+        if (written < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+                return 0;
+            }
+            return -1;
+        }
+        if (written == 0) {
+            return 0;
+        }
+        h2_connection_consume_output(&client->conn, (size_t)written);
+    }
+    return 0;
+}
+
+static int h2_read_client(h2_client *client)
+{
+    uint8_t buffer[8192];
+
+    for (;;) {
+        ssize_t got;
+
+        got = read(client->fd, buffer, sizeof(buffer));
+        if (got < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return 0;
+            }
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (got == 0) {
+            return 1;
+        }
+        if (h2_connection_feed(&client->conn, buffer, (size_t)got) != H2_OK && !h2_connection_wants_write(&client->conn)) {
+            return -1;
+        }
+    }
+}
+
+static int h2_accept_clients(h2_io *io, h2_client *clients, int listener_fd, unsigned *accepted_count)
+{
+    for (;;) {
+        struct sockaddr_in addr;
+        socklen_t addr_len;
+        h2_client *client;
+        int fd;
+
+        addr_len = sizeof(addr);
+        fd = accept(listener_fd, (struct sockaddr *)&addr, &addr_len);
+        if (fd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return 0;
+            }
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (h2_set_nonblock(fd) != 0) {
+            close(fd);
+            continue;
+        }
+        client = h2_alloc_client(clients, fd);
+        if (client == NULL) {
+            close(fd);
+            continue;
+        }
+        if (h2_io_add_connection(io, fd) != 0) {
+            h2_close_client(io, client);
+            continue;
+        }
+        (*accepted_count)++;
+    }
+}
+
+int h2_server_run(const h2_server_config *config)
+{
+    h2_client clients[H2_SERVER_MAX_CLIENTS];
+    h2_event events[64];
+    h2_io io;
+    uint16_t bound_port;
+    unsigned accepted_count;
+    int listener_fd;
+    int exit_code;
+
+    if (config == NULL || config->host == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    signal(SIGPIPE, SIG_IGN);
+    memset(clients, 0, sizeof(clients));
+    listener_fd = h2_create_listener(config, &bound_port);
+    if (listener_fd < 0) {
+        return -1;
+    }
+    if (h2_io_init(&io) != 0) {
+        close(listener_fd);
+        return -1;
+    }
+    if (h2_io_add_listener(&io, listener_fd) != 0 || h2_write_ready_file(config->ready_file, bound_port) != 0) {
+        h2_io_close(&io);
+        close(listener_fd);
+        return -1;
+    }
+    fprintf(stderr, "h2d listening on %s:%u using %s\n", config->host, (unsigned)bound_port, h2_io_backend_name());
+    accepted_count = 0u;
+    exit_code = 0;
+    for (;;) {
+        int count;
+        int pos;
+
+        if (config->max_connections > 0u && accepted_count >= config->max_connections && h2_active_client_count(clients) == 0u) {
+            break;
+        }
+        count = h2_io_wait(&io, events, sizeof(events) / sizeof(events[0]), -1);
+        if (count < 0) {
+            exit_code = -1;
+            break;
+        }
+        for (pos = 0; pos < count; pos++) {
+            h2_client *client;
+            bool close_after;
+
+            if (events[pos].fd == listener_fd) {
+                if (events[pos].readable && h2_accept_clients(&io, clients, listener_fd, &accepted_count) != 0) {
+                    exit_code = -1;
+                }
+                continue;
+            }
+            client = h2_find_client(clients, events[pos].fd);
+            if (client == NULL) {
+                continue;
+            }
+            close_after = false;
+            if (events[pos].readable) {
+                int read_result;
+
+                read_result = h2_read_client(client);
+                if (read_result < 0) {
+                    close_after = true;
+                } else if (read_result > 0) {
+                    close_after = true;
+                }
+            }
+            if (events[pos].closed) {
+                close_after = true;
+            }
+            if (h2_connection_wants_write(&client->conn) && h2_flush_client(client) != 0) {
+                close_after = true;
+            }
+            if (close_after && !h2_connection_wants_write(&client->conn)) {
+                h2_close_client(&io, client);
+            } else if (!close_after) {
+                (void)h2_io_mod_connection(&io, client->fd, h2_connection_wants_write(&client->conn));
+            }
+        }
+        if (exit_code != 0) {
+            break;
+        }
+    }
+    for (size_t pos = 0u; pos < H2_SERVER_MAX_CLIENTS; pos++) {
+        if (clients[pos].used) {
+            h2_close_client(&io, &clients[pos]);
+        }
+    }
+    h2_io_close(&io);
+    close(listener_fd);
+    return exit_code;
+}

--- a/phase1/http2/src/server.c
+++ b/phase1/http2/src/server.c
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -233,7 +234,7 @@ static int h2_accept_clients(h2_io *io, h2_client *clients, int listener_fd, uns
 
 int h2_server_run(const h2_server_config *config)
 {
-    h2_client clients[H2_SERVER_MAX_CLIENTS];
+    h2_client *clients;
     h2_event events[64];
     h2_io io;
     uint16_t bound_port;
@@ -246,18 +247,24 @@ int h2_server_run(const h2_server_config *config)
         return -1;
     }
     signal(SIGPIPE, SIG_IGN);
-    memset(clients, 0, sizeof(clients));
+    clients = calloc(H2_SERVER_MAX_CLIENTS, sizeof(*clients));
+    if (clients == NULL) {
+        return -1;
+    }
     listener_fd = h2_create_listener(config, &bound_port);
     if (listener_fd < 0) {
+        free(clients);
         return -1;
     }
     if (h2_io_init(&io) != 0) {
         close(listener_fd);
+        free(clients);
         return -1;
     }
     if (h2_io_add_listener(&io, listener_fd) != 0 || h2_write_ready_file(config->ready_file, bound_port) != 0) {
         h2_io_close(&io);
         close(listener_fd);
+        free(clients);
         return -1;
     }
     fprintf(stderr, "h2d listening on %s:%u using %s\n", config->host, (unsigned)bound_port, h2_io_backend_name());
@@ -323,5 +330,6 @@ int h2_server_run(const h2_server_config *config)
     }
     h2_io_close(&io);
     close(listener_fd);
+    free(clients);
     return exit_code;
 }

--- a/phase1/http2/src/stream.c
+++ b/phase1/http2/src/stream.c
@@ -1,0 +1,71 @@
+#include "http2/stream.h"
+
+#include <limits.h>
+#include <string.h>
+
+void h2_stream_init(h2_stream *stream, uint32_t stream_id, int32_t initial_window)
+{
+    memset(stream, 0, sizeof(*stream));
+    stream->id = stream_id;
+    stream->state = H2_STREAM_STATE_IDLE;
+    stream->send_window = initial_window;
+    stream->recv_window = H2_DEFAULT_WINDOW_SIZE;
+}
+
+int h2_stream_receive_headers(h2_stream *stream, bool end_stream)
+{
+    if (stream == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (stream->state != H2_STREAM_STATE_IDLE) {
+        return H2_PROTOCOL_ERROR;
+    }
+    stream->state = end_stream ? H2_STREAM_STATE_HALF_CLOSED_REMOTE : H2_STREAM_STATE_OPEN;
+    return H2_OK;
+}
+
+int h2_stream_receive_data(h2_stream *stream, size_t data_len, bool end_stream)
+{
+    if (stream == NULL || data_len > (size_t)INT32_MAX) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (stream->state != H2_STREAM_STATE_OPEN && stream->state != H2_STREAM_STATE_HALF_CLOSED_LOCAL) {
+        return H2_STREAM_CLOSED;
+    }
+    if (stream->recv_window < (int32_t)data_len) {
+        return H2_FLOW_CONTROL_ERROR;
+    }
+    stream->recv_window -= (int32_t)data_len;
+    if (end_stream) {
+        stream->state = stream->state == H2_STREAM_STATE_HALF_CLOSED_LOCAL ? H2_STREAM_STATE_CLOSED : H2_STREAM_STATE_HALF_CLOSED_REMOTE;
+    }
+    return H2_OK;
+}
+
+int h2_stream_send_end_stream(h2_stream *stream)
+{
+    if (stream == NULL) {
+        return H2_INTERNAL_ERROR;
+    }
+    if (stream->state == H2_STREAM_STATE_OPEN) {
+        stream->state = H2_STREAM_STATE_HALF_CLOSED_LOCAL;
+        return H2_OK;
+    }
+    if (stream->state == H2_STREAM_STATE_HALF_CLOSED_REMOTE) {
+        stream->state = H2_STREAM_STATE_CLOSED;
+        return H2_OK;
+    }
+    return H2_STREAM_CLOSED;
+}
+
+int h2_stream_add_send_window(h2_stream *stream, uint32_t increment)
+{
+    if (stream == NULL || increment == 0u) {
+        return H2_PROTOCOL_ERROR;
+    }
+    if (increment > (uint32_t)(INT32_MAX - stream->send_window)) {
+        return H2_FLOW_CONTROL_ERROR;
+    }
+    stream->send_window += (int32_t)increment;
+    return H2_OK;
+}

--- a/phase1/http2/tests/connection_test.c
+++ b/phase1/http2/tests/connection_test.c
@@ -1,0 +1,123 @@
+#include "http2/connection.h"
+#include "http2/hpack.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define EXPECT_TRUE(expr) do { if (!(expr)) { fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); return 1; } } while (0)
+#define EXPECT_EQ_INT(got, want) EXPECT_TRUE((int)(got) == (int)(want))
+#define EXPECT_EQ_SIZE(got, want) EXPECT_TRUE((size_t)(got) == (size_t)(want))
+
+static size_t append_request(uint8_t *wire, size_t cap)
+{
+    h2_setting settings[1];
+    uint8_t header_block[32];
+    size_t pos;
+    size_t chunk_len;
+    size_t wire_pos;
+
+    wire_pos = 0u;
+    memcpy(wire + wire_pos, H2_CLIENT_PREFACE, H2_CLIENT_PREFACE_LEN);
+    wire_pos += H2_CLIENT_PREFACE_LEN;
+
+    settings[0].id = H2_SETTINGS_ENABLE_PUSH;
+    settings[0].value = 0u;
+    chunk_len = h2_frame_encode_settings(wire + wire_pos, cap - wire_pos, 0u, settings, 1u);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    wire_pos += chunk_len;
+
+    pos = 0u;
+    chunk_len = h2_hpack_encode_indexed(header_block + pos, sizeof(header_block) - pos, 2u);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_indexed(header_block + pos, sizeof(header_block) - pos, 6u);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_indexed(header_block + pos, sizeof(header_block) - pos, 4u);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    pos += chunk_len;
+    chunk_len = h2_frame_encode_headers(wire + wire_pos, cap - wire_pos, 1u, H2_FLAG_END_HEADERS | H2_FLAG_END_STREAM, header_block, pos);
+    if (chunk_len == 0u) {
+        return 0u;
+    }
+    wire_pos += chunk_len;
+    return wire_pos;
+}
+
+static int test_connection_serves_path(void)
+{
+    h2_connection conn;
+    uint8_t request[256];
+    h2_frame_header header;
+    size_t request_len;
+    size_t pos;
+    const uint8_t *out;
+    size_t out_len;
+    int data_seen;
+
+    /* given a client preface, SETTINGS, and GET / HEADERS */
+    h2_connection_init(&conn);
+    request_len = append_request(request, sizeof(request));
+    EXPECT_TRUE(request_len > 0u);
+
+    /* when feeding the connection state machine */
+    EXPECT_EQ_INT(h2_connection_feed(&conn, request, request_len), H2_OK);
+
+    /* then it queues server settings, ACK, response headers, and DATA echoing :path */
+    out = h2_connection_output(&conn);
+    out_len = h2_connection_output_len(&conn);
+    EXPECT_TRUE(out != NULL);
+    EXPECT_TRUE(out_len >= H2_FRAME_HEADER_LEN);
+    data_seen = 0;
+    pos = 0u;
+    while (pos + H2_FRAME_HEADER_LEN <= out_len) {
+        EXPECT_EQ_INT(h2_frame_parse_header(out + pos, out_len - pos, &header), H2_OK);
+        pos += H2_FRAME_HEADER_LEN;
+        EXPECT_TRUE(pos + header.length <= out_len);
+        if (header.type == H2_FRAME_DATA) {
+            h2_data_payload payload;
+
+            EXPECT_EQ_INT(h2_frame_parse_data(&header, out + pos, &payload), H2_OK);
+            EXPECT_EQ_SIZE(payload.data_len, 2u);
+            EXPECT_TRUE(memcmp(payload.data, "/\n", 2u) == 0);
+            data_seen = 1;
+        }
+        pos += header.length;
+    }
+    EXPECT_TRUE(data_seen == 1);
+    return 0;
+}
+
+static int test_connection_rejects_bad_preface(void)
+{
+    h2_connection conn;
+    uint8_t bad[H2_CLIENT_PREFACE_LEN];
+
+    /* given bytes that are not the HTTP/2 client preface */
+    h2_connection_init(&conn);
+    memcpy(bad, H2_CLIENT_PREFACE, sizeof(bad));
+    bad[10] = '1';
+
+    /* when feeding them to the connection */
+    EXPECT_EQ_INT(h2_connection_feed(&conn, bad, sizeof(bad)), H2_PROTOCOL_ERROR);
+
+    /* then a GOAWAY is queued */
+    EXPECT_TRUE(h2_connection_wants_write(&conn));
+    return 0;
+}
+
+int main(void)
+{
+    EXPECT_EQ_INT(test_connection_serves_path(), 0);
+    EXPECT_EQ_INT(test_connection_rejects_bad_preface(), 0);
+    puts("connection_test: ok");
+    return 0;
+}

--- a/phase1/http2/tests/frame_test.c
+++ b/phase1/http2/tests/frame_test.c
@@ -1,0 +1,341 @@
+#include "http2/frame.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define EXPECT_TRUE(expr) do { if (!(expr)) { fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); return 1; } } while (0)
+#define EXPECT_EQ_U32(got, want) EXPECT_TRUE((uint32_t)(got) == (uint32_t)(want))
+#define EXPECT_EQ_SIZE(got, want) EXPECT_TRUE((size_t)(got) == (size_t)(want))
+#define EXPECT_EQ_INT(got, want) EXPECT_TRUE((int)(got) == (int)(want))
+
+static int test_header_reserved_bit_cleared(void)
+{
+    uint8_t wire[H2_FRAME_HEADER_LEN] = { 0x00u, 0x00u, 0x00u, H2_FRAME_SETTINGS, 0x00u, 0x80u, 0x00u, 0x00u, 0x05u };
+    h2_frame_header header;
+
+    /* given a frame header with the stream-id reserved bit set */
+    /* when parsing the common 9-octet frame header */
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, sizeof(wire), &header), H2_OK);
+
+    /* then the reserved bit is ignored and cleared from stream_id */
+    EXPECT_EQ_U32(header.stream_id, 5u);
+    return 0;
+}
+
+static int test_data_frame(void)
+{
+    const uint8_t data[] = { 'a', 'b', 'c' };
+    uint8_t wire[64];
+    h2_frame_header header;
+    h2_data_payload payload;
+    size_t wire_len;
+
+    /* given a DATA payload for stream 1 */
+    /* when encoding and parsing the DATA frame */
+    wire_len = h2_frame_encode_data(wire, sizeof(wire), 1u, H2_FLAG_END_STREAM, data, sizeof(data));
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + sizeof(data));
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_data(&header, wire + H2_FRAME_HEADER_LEN, &payload), H2_OK);
+
+    /* then type, stream, flags, and payload round-trip */
+    EXPECT_EQ_U32(header.type, H2_FRAME_DATA);
+    EXPECT_EQ_U32(header.flags, H2_FLAG_END_STREAM);
+    EXPECT_EQ_U32(header.stream_id, 1u);
+    EXPECT_EQ_SIZE(payload.data_len, sizeof(data));
+    EXPECT_TRUE(memcmp(payload.data, data, sizeof(data)) == 0);
+
+    /* given DATA on stream 0 */
+    /* when validating the frame */
+    header.stream_id = 0u;
+
+    /* then it is rejected as a protocol error */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_PROTOCOL_ERROR);
+    return 0;
+}
+
+static int test_headers_frame(void)
+{
+    const uint8_t block[] = { 0x82u, 0x84u };
+    uint8_t wire[64];
+    h2_frame_header header;
+    h2_headers_payload payload;
+    size_t wire_len;
+
+    /* given a small HEADERS block */
+    /* when encoding and parsing HEADERS */
+    wire_len = h2_frame_encode_headers(wire, sizeof(wire), 3u, H2_FLAG_END_HEADERS, block, sizeof(block));
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + sizeof(block));
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_headers(&header, wire + H2_FRAME_HEADER_LEN, &payload), H2_OK);
+
+    /* then the header block fragment round-trips */
+    EXPECT_EQ_U32(header.type, H2_FRAME_HEADERS);
+    EXPECT_EQ_U32(header.stream_id, 3u);
+    EXPECT_EQ_SIZE(payload.header_block_len, sizeof(block));
+    EXPECT_TRUE(memcmp(payload.header_block, block, sizeof(block)) == 0);
+
+    /* given HEADERS with stream 0 */
+    /* when validating it */
+    header.stream_id = 0u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_PROTOCOL_ERROR);
+    return 0;
+}
+
+static int test_priority_frame(void)
+{
+    h2_priority_payload priority;
+    h2_priority_payload parsed;
+    uint8_t wire[64];
+    h2_frame_header header;
+    size_t wire_len;
+
+    /* given a PRIORITY payload */
+    priority.exclusive = true;
+    priority.stream_dependency = 7u;
+    priority.weight = 42u;
+
+    /* when encoding and parsing PRIORITY */
+    wire_len = h2_frame_encode_priority(wire, sizeof(wire), 5u, &priority);
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 5u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_priority(&header, wire + H2_FRAME_HEADER_LEN, &parsed), H2_OK);
+
+    /* then exclusive, dependency, and weight round-trip */
+    EXPECT_TRUE(parsed.exclusive);
+    EXPECT_EQ_U32(parsed.stream_dependency, 7u);
+    EXPECT_EQ_U32(parsed.weight, 42u);
+
+    /* given a PRIORITY header with bad length */
+    /* when validating it */
+    header.length = 4u;
+
+    /* then it is rejected with FRAME_SIZE_ERROR */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_rst_stream_frame(void)
+{
+    uint8_t wire[64];
+    h2_frame_header header;
+    uint32_t error_code;
+    size_t wire_len;
+
+    /* given an RST_STREAM error code */
+    /* when encoding and parsing RST_STREAM */
+    wire_len = h2_frame_encode_rst_stream(wire, sizeof(wire), 7u, H2_CANCEL);
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 4u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_rst_stream(&header, wire + H2_FRAME_HEADER_LEN, &error_code), H2_OK);
+
+    /* then the error code round-trips */
+    EXPECT_EQ_U32(error_code, H2_CANCEL);
+
+    /* given RST_STREAM with length 3 */
+    /* when validating it */
+    header.length = 3u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_settings_frame(void)
+{
+    h2_setting settings[2];
+    h2_setting parsed[2];
+    uint8_t wire[64];
+    h2_frame_header header;
+    size_t parsed_len;
+    size_t wire_len;
+
+    /* given two SETTINGS entries */
+    settings[0].id = H2_SETTINGS_ENABLE_PUSH;
+    settings[0].value = 0u;
+    settings[1].id = H2_SETTINGS_MAX_FRAME_SIZE;
+    settings[1].value = H2_DEFAULT_MAX_FRAME_SIZE;
+
+    /* when encoding and parsing SETTINGS */
+    wire_len = h2_frame_encode_settings(wire, sizeof(wire), 0u, settings, 2u);
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 12u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_settings(&header, wire + H2_FRAME_HEADER_LEN, parsed, 2u, &parsed_len), H2_OK);
+
+    /* then the entries round-trip */
+    EXPECT_EQ_SIZE(parsed_len, 2u);
+    EXPECT_EQ_U32(parsed[0].id, H2_SETTINGS_ENABLE_PUSH);
+    EXPECT_EQ_U32(parsed[0].value, 0u);
+    EXPECT_EQ_U32(parsed[1].id, H2_SETTINGS_MAX_FRAME_SIZE);
+    EXPECT_EQ_U32(parsed[1].value, H2_DEFAULT_MAX_FRAME_SIZE);
+
+    /* given SETTINGS ACK with non-empty payload */
+    /* when validating it */
+    header.flags = H2_FLAG_ACK;
+    header.length = 6u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_push_promise_frame(void)
+{
+    const uint8_t block[] = { 0x84u };
+    uint8_t wire[64];
+    h2_frame_header header;
+    h2_push_promise_payload payload;
+    size_t wire_len;
+
+    /* given a PUSH_PROMISE payload */
+    /* when encoding and parsing PUSH_PROMISE */
+    wire_len = h2_frame_encode_push_promise(wire, sizeof(wire), 1u, H2_FLAG_END_HEADERS, 2u, block, sizeof(block));
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 5u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_push_promise(&header, wire + H2_FRAME_HEADER_LEN, &payload), H2_OK);
+
+    /* then promised stream id and header block round-trip */
+    EXPECT_EQ_U32(payload.promised_stream_id, 2u);
+    EXPECT_EQ_SIZE(payload.header_block_len, sizeof(block));
+    EXPECT_TRUE(memcmp(payload.header_block, block, sizeof(block)) == 0);
+
+    /* given PUSH_PROMISE with too-short length */
+    /* when validating it */
+    header.length = 3u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_ping_frame(void)
+{
+    const uint8_t opaque[8] = { 'p', 'i', 'n', 'g', 'd', 'a', 't', 'a' };
+    uint8_t parsed[8];
+    uint8_t wire[64];
+    h2_frame_header header;
+    size_t wire_len;
+
+    /* given opaque PING bytes */
+    /* when encoding and parsing PING */
+    wire_len = h2_frame_encode_ping(wire, sizeof(wire), H2_FLAG_ACK, opaque);
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 8u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_ping(&header, wire + H2_FRAME_HEADER_LEN, parsed), H2_OK);
+
+    /* then the opaque bytes round-trip */
+    EXPECT_TRUE(memcmp(parsed, opaque, sizeof(parsed)) == 0);
+
+    /* given PING with length 7 */
+    /* when validating it */
+    header.length = 7u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_goaway_frame(void)
+{
+    const uint8_t debug[] = { 'b', 'y', 'e' };
+    uint8_t wire[64];
+    h2_frame_header header;
+    h2_goaway_payload payload;
+    size_t wire_len;
+
+    /* given a GOAWAY payload */
+    /* when encoding and parsing GOAWAY */
+    wire_len = h2_frame_encode_goaway(wire, sizeof(wire), 9u, H2_OK, debug, sizeof(debug));
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 8u + sizeof(debug));
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_goaway(&header, wire + H2_FRAME_HEADER_LEN, &payload), H2_OK);
+
+    /* then stream id, error code, and debug data round-trip */
+    EXPECT_EQ_U32(payload.last_stream_id, 9u);
+    EXPECT_EQ_U32(payload.error_code, H2_OK);
+    EXPECT_EQ_SIZE(payload.debug_len, sizeof(debug));
+    EXPECT_TRUE(memcmp(payload.debug_data, debug, sizeof(debug)) == 0);
+
+    /* given GOAWAY with length 7 */
+    /* when validating it */
+    header.length = 7u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_FRAME_SIZE_ERROR);
+    return 0;
+}
+
+static int test_window_update_frame(void)
+{
+    uint8_t wire[64];
+    h2_frame_header header;
+    uint32_t increment;
+    size_t wire_len;
+
+    /* given a WINDOW_UPDATE increment */
+    /* when encoding and parsing WINDOW_UPDATE */
+    wire_len = h2_frame_encode_window_update(wire, sizeof(wire), 0u, 1024u);
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + 4u);
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_window_update(&header, wire + H2_FRAME_HEADER_LEN, &increment), H2_OK);
+
+    /* then the increment round-trips */
+    EXPECT_EQ_U32(increment, 1024u);
+
+    /* given WINDOW_UPDATE with zero increment */
+    /* when parsing it */
+    wire[H2_FRAME_HEADER_LEN + 0u] = 0u;
+    wire[H2_FRAME_HEADER_LEN + 1u] = 0u;
+    wire[H2_FRAME_HEADER_LEN + 2u] = 0u;
+    wire[H2_FRAME_HEADER_LEN + 3u] = 0u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_parse_window_update(&header, wire + H2_FRAME_HEADER_LEN, &increment), H2_PROTOCOL_ERROR);
+    return 0;
+}
+
+static int test_continuation_frame(void)
+{
+    const uint8_t block[] = { 0x40u, 0x00u, 0x00u };
+    uint8_t wire[64];
+    h2_frame_header header;
+    h2_continuation_payload payload;
+    size_t wire_len;
+
+    /* given a CONTINUATION fragment */
+    /* when encoding and parsing CONTINUATION */
+    wire_len = h2_frame_encode_continuation(wire, sizeof(wire), 11u, H2_FLAG_END_HEADERS, block, sizeof(block));
+    EXPECT_EQ_SIZE(wire_len, H2_FRAME_HEADER_LEN + sizeof(block));
+    EXPECT_EQ_INT(h2_frame_parse_header(wire, wire_len, &header), H2_OK);
+    EXPECT_EQ_INT(h2_frame_parse_continuation(&header, wire + H2_FRAME_HEADER_LEN, &payload), H2_OK);
+
+    /* then the fragment round-trips */
+    EXPECT_EQ_SIZE(payload.header_block_len, sizeof(block));
+    EXPECT_TRUE(memcmp(payload.header_block, block, sizeof(block)) == 0);
+
+    /* given CONTINUATION on stream 0 */
+    /* when validating it */
+    header.stream_id = 0u;
+
+    /* then it is rejected */
+    EXPECT_EQ_INT(h2_frame_validate_payload(&header), H2_PROTOCOL_ERROR);
+    return 0;
+}
+
+int main(void)
+{
+    EXPECT_EQ_INT(test_header_reserved_bit_cleared(), 0);
+    EXPECT_EQ_INT(test_data_frame(), 0);
+    EXPECT_EQ_INT(test_headers_frame(), 0);
+    EXPECT_EQ_INT(test_priority_frame(), 0);
+    EXPECT_EQ_INT(test_rst_stream_frame(), 0);
+    EXPECT_EQ_INT(test_settings_frame(), 0);
+    EXPECT_EQ_INT(test_push_promise_frame(), 0);
+    EXPECT_EQ_INT(test_ping_frame(), 0);
+    EXPECT_EQ_INT(test_goaway_frame(), 0);
+    EXPECT_EQ_INT(test_window_update_frame(), 0);
+    EXPECT_EQ_INT(test_continuation_frame(), 0);
+    puts("frame_test: ok");
+    return 0;
+}

--- a/phase1/http2/tests/hpack_test.c
+++ b/phase1/http2/tests/hpack_test.c
@@ -1,0 +1,103 @@
+#include "http2/hpack.h"
+#include "http2/hpack_static.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define EXPECT_TRUE(expr) do { if (!(expr)) { fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #expr); return 1; } } while (0)
+#define EXPECT_EQ_INT(got, want) EXPECT_TRUE((int)(got) == (int)(want))
+#define EXPECT_EQ_SIZE(got, want) EXPECT_TRUE((size_t)(got) == (size_t)(want))
+
+static int test_static_table(void)
+{
+    const h2_hpack_static_entry *entry;
+
+    /* given RFC 7541 Appendix A static table indexes */
+    /* when looking up common pseudo-headers */
+    entry = h2_hpack_static_get(8u);
+
+    /* then index 8 is :status 200 */
+    EXPECT_TRUE(entry != NULL);
+    EXPECT_TRUE(strcmp(entry->name, ":status") == 0);
+    EXPECT_TRUE(strcmp(entry->value, "200") == 0);
+    EXPECT_TRUE(h2_hpack_static_get(61u) != NULL);
+    EXPECT_TRUE(h2_hpack_static_get(62u) == NULL);
+    return 0;
+}
+
+static int test_hpack_integer(void)
+{
+    uint8_t wire[8];
+    uint32_t value;
+    size_t used;
+    size_t wire_len;
+
+    /* given an HPACK integer larger than the prefix */
+    /* when encoding and decoding it */
+    wire_len = h2_hpack_encode_integer(wire, sizeof(wire), 5u, 0x20u, 1337u);
+    EXPECT_TRUE(wire_len > 1u);
+    EXPECT_EQ_INT(h2_hpack_decode_integer(wire, wire_len, 5u, &value, &used), H2_OK);
+
+    /* then value and consumed length round-trip */
+    EXPECT_EQ_SIZE(used, wire_len);
+    EXPECT_TRUE(value == 1337u);
+    return 0;
+}
+
+static int test_hpack_decode_request_path(void)
+{
+    uint8_t block[64];
+    char path[64];
+    size_t pos;
+    size_t chunk_len;
+
+    /* given a static-table-only request header block */
+    pos = 0u;
+    chunk_len = h2_hpack_encode_indexed(block + pos, sizeof(block) - pos, 2u);
+    EXPECT_TRUE(chunk_len > 0u);
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_indexed(block + pos, sizeof(block) - pos, 6u);
+    EXPECT_TRUE(chunk_len > 0u);
+    pos += chunk_len;
+    chunk_len = h2_hpack_encode_indexed(block + pos, sizeof(block) - pos, 4u);
+    EXPECT_TRUE(chunk_len > 0u);
+    pos += chunk_len;
+
+    /* when extracting :path */
+    EXPECT_EQ_INT(h2_hpack_extract_path(block, pos, path, sizeof(path)), H2_OK);
+
+    /* then the static :path / value is returned */
+    EXPECT_TRUE(strcmp(path, "/") == 0);
+    return 0;
+}
+
+static int test_hpack_decode_literal(void)
+{
+    uint8_t block[128];
+    h2_header_field fields[2];
+    size_t field_len;
+    size_t block_len;
+
+    /* given a literal header with a new name */
+    block_len = h2_hpack_encode_literal_new_name(block, sizeof(block), "server", "c11-h2");
+    EXPECT_TRUE(block_len > 0u);
+
+    /* when decoding the header block */
+    EXPECT_EQ_INT(h2_hpack_decode_headers(block, block_len, fields, 2u, &field_len), H2_OK);
+
+    /* then name and value round-trip */
+    EXPECT_EQ_SIZE(field_len, 1u);
+    EXPECT_TRUE(strcmp(fields[0].name, "server") == 0);
+    EXPECT_TRUE(strcmp(fields[0].value, "c11-h2") == 0);
+    return 0;
+}
+
+int main(void)
+{
+    EXPECT_EQ_INT(test_static_table(), 0);
+    EXPECT_EQ_INT(test_hpack_integer(), 0);
+    EXPECT_EQ_INT(test_hpack_decode_request_path(), 0);
+    EXPECT_EQ_INT(test_hpack_decode_literal(), 0);
+    puts("hpack_test: ok");
+    return 0;
+}

--- a/phase1/http2/tests/smoke.sh
+++ b/phase1/http2/tests/smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! curl --help all 2>/dev/null | grep -q -- '--http2-prior-knowledge'; then
+  echo "curl lacks --http2-prior-knowledge; cannot run h2c smoke on this host"
+  exit 0
+fi
+
+ready_file="$(mktemp -t h2d-ready.XXXXXX)"
+body_file="$(mktemp -t h2d-body.XXXXXX)"
+rm -f "$ready_file"
+
+./build/h2d --host 127.0.0.1 --port 0 --ready-file "$ready_file" --max-connections 1 &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true; rm -f "$ready_file" "$body_file"' EXIT
+
+tries=0
+while [ ! -s "$ready_file" ] && [ "$tries" -lt 1000000 ]; do
+  tries=$((tries + 1))
+done
+
+if [ ! -s "$ready_file" ]; then
+  echo "server did not publish ready file" >&2
+  exit 1
+fi
+
+port="$(tr -d '\r\n' < "$ready_file")"
+curl --max-time 5 --http2-prior-knowledge -sS -o "$body_file" "http://127.0.0.1:${port}/"
+
+if ! cmp -s "$body_file" - <<'EXPECTED'
+/
+EXPECTED
+then
+  echo "unexpected response body:" >&2
+  cat "$body_file" >&2
+  exit 1
+fi
+
+wait "$server_pid"
+echo "smoke: ok"


### PR DESCRIPTION
{[http2-engineer]} Link: #3

## Summary
- Implements a pure C11 HTTP/2 h2c server under `phase1/http2/` with RFC 7540 frame parsing/serialization, static-table-only HPACK, stream state, and flow control.
- Adds macOS kqueue auto-selection and Linux `IO=epoll|io_uring` backends selected by Makefile macros.
- Adds unit tests for frame/HPACK/connection behavior plus a `curl --http2-prior-knowledge` E2E smoke test that verifies the response body echoes `:path`.

## Verification
- `make clean && make all && make test && make smoke` on macOS/kqueue
- `docker run --rm -v ... gcc:14 ... make IO=epoll all test`
- `docker run --rm -v ... gcc:14 ... make IO=io_uring all test`
- `lsp_diagnostics` on changed C sources: 0 errors

## Notes
- Dynamic HPACK table and Huffman decoding are intentionally deferred from v1 per issue guidance.
- Branch push did not create a CI run because current workflows trigger Phase-1 checks on `pull_request` for non-master branches; this PR should trigger the required CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 1 delivers a pure C11 HTTP/2 (h2c) server with RFC 7540 frames, static-table HPACK, stream state, and flow control, plus macOS `kqueue` and Linux `epoll`/`io_uring` backends. Adds unit and smoke tests; responses echo the request `:path`.

- **New Features**
  - HTTP/2 core: frame parsing/serialization, static-table-only HPACK (encode/decode), stream lifecycle, and connection/stream flow control.
  - IO backends: macOS auto-selects `kqueue`; Linux selects `IO=epoll` or `IO=io_uring` via the Makefile.
  - Tests: unit tests for frame/HPACK/connection and a `curl --http2-prior-knowledge` smoke test; fixes Linux smoke startup by waiting on a ready file.

- **Migration**
  - Build/tests: `make clean && make all && make test && make smoke` (macOS); Linux: `make IO=epoll all test` or `make IO=io_uring all test`.
  - Run: `./build/h2d --host 127.0.0.1 --port 0 --ready-file <path> --max-connections N`.
  - Scope per `http2-engineer` Phase‑1: dynamic HPACK table and Huffman decoding are deferred.

<sup>Written for commit 85d81412e41a9b67f5408307a3d79924d1d7a085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

