### PR TITLE
[http2-engineer] phase-1 / HTTP/2 stack-budget hygiene v2

### DIFF
--- a/phase1/http2/src/server.c
+++ b/phase1/http2/src/server.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -96,6 +97,20 @@ static int h2_write_ready_file(const char *path, uint16_t port)
         return -1;
     }
     return 0;
+}
+
+static void h2_log_stack_limit(void)
+{
+    struct rlimit limit;
+
+    if (getrlimit(RLIMIT_STACK, &limit) != 0) {
+        return;
+    }
+    if (limit.rlim_cur == RLIM_INFINITY) {
+        fprintf(stderr, "h2d stack limit: unlimited\n");
+    } else {
+        fprintf(stderr, "h2d stack limit: %llu bytes\n", (unsigned long long)limit.rlim_cur);
+    }
 }
 
 static h2_client *h2_find_client(h2_client *clients, int fd)
@@ -247,6 +262,8 @@ int h2_server_run(const h2_server_config *config)
         return -1;
     }
     signal(SIGPIPE, SIG_IGN);
+    h2_log_stack_limit();
+    /* h2_connection owns large I/O buffers; keep the client table off the startup stack. */
     clients = calloc(H2_SERVER_MAX_CLIENTS, sizeof(*clients));
     if (clients == NULL) {
         return -1;

--- a/phase1/http2/src/server.c
+++ b/phase1/http2/src/server.c
@@ -104,6 +104,10 @@ static void h2_log_stack_limit(void)
     struct rlimit limit;
 
     if (getrlimit(RLIMIT_STACK, &limit) != 0) {
+        int error;
+
+        error = errno;
+        fprintf(stderr, "h2d stack limit: unavailable (errno=%d %s)\n", error, strerror(error));
         return;
     }
     if (limit.rlim_cur == RLIM_INFINITY) {


### PR DESCRIPTION
## Summary
- {[http2-engineer]} Log the process `RLIMIT_STACK` value when `h2d` starts.
- Document why the HTTP/2 client table stays heap-allocated after the Linux smoke stack-overflow fix.

## Why
- Logging the stack rlimit at startup makes future stack-overflow regressions debuggable from the run log alone, without needing to attach gdb/lldb.

## Verification
- `make clean test smoke` in `phase1/http2`
- `git diff --check origin/master..HEAD`

## Status
- Done: branch pushed as `phase1/http2/v2-stack-budget-hygiene` with one targeted commit.
- To Do: full review/QA/verifier/CI gate after PR opens.
- Blockers: none.
