### PR TITLE
[quick-engineer] phase-1 / CI: gate phase3-verify on phase2/build.zig (cubic-dev-ai PR #6 follow-up)

### DIFF
--- a/.github/workflows/phase3-verify.yml
+++ b/.github/workflows/phase3-verify.yml
@@ -20,7 +20,8 @@ jobs:
       has_diff: ${{ steps.detect.outputs.has_diff }}
       has_cross: ${{ steps.detect.outputs.has_cross }}
       has_zig: ${{ steps.detect.outputs.has_zig }}
-      ready: ${{ steps.detect.outputs.ready }}
+      should_run_diff: ${{ steps.detect.outputs.should_run_diff }}
+      should_run_cross: ${{ steps.detect.outputs.should_run_cross }}
     steps:
       - uses: actions/checkout@v4
       - id: detect
@@ -35,15 +36,22 @@ jobs:
           if [ ${#missing[@]} -gt 0 ]; then
             printf 'phase-3 prerequisites missing — affected jobs will be skipped:\n'
             printf '  - %s\n' "${missing[@]}"
-            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f phase3/run-diff.sh ] && [ -f phase2/build.zig ]; then
+            echo "should_run_diff=true" >> "$GITHUB_OUTPUT"
           else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "should_run_diff=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f phase3/run-cross-docker.sh ] && [ -f phase2/build.zig ]; then
+            echo "should_run_cross=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run_cross=false" >> "$GITHUB_OUTPUT"
           fi
 
   zcc-vs-gcc:
     name: zcc-vs-gcc differential (${{ matrix.os }})
     needs: guard
-    if: needs.guard.outputs.ready == 'true'
+    if: needs.guard.outputs.should_run_diff == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +74,7 @@ jobs:
   cross-compile-linux:
     name: zcc cross-compile (linux x86_64) under docker
     needs: guard
-    if: needs.guard.outputs.ready == 'true'
+    if: needs.guard.outputs.should_run_cross == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phase3-verify.yml
+++ b/.github/workflows/phase3-verify.yml
@@ -20,6 +20,7 @@ jobs:
       has_diff: ${{ steps.detect.outputs.has_diff }}
       has_cross: ${{ steps.detect.outputs.has_cross }}
       has_zig: ${{ steps.detect.outputs.has_zig }}
+      ready: ${{ steps.detect.outputs.ready }}
     steps:
       - uses: actions/checkout@v4
       - id: detect
@@ -34,12 +35,15 @@ jobs:
           if [ ${#missing[@]} -gt 0 ]; then
             printf 'phase-3 prerequisites missing — affected jobs will be skipped:\n'
             printf '  - %s\n' "${missing[@]}"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
           fi
 
   zcc-vs-gcc:
     name: zcc-vs-gcc differential (${{ matrix.os }})
     needs: guard
-    if: needs.guard.outputs.has_diff == 'true' && needs.guard.outputs.has_zig == 'true'
+    if: needs.guard.outputs.ready == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +66,7 @@ jobs:
   cross-compile-linux:
     name: zcc cross-compile (linux x86_64) under docker
     needs: guard
-    if: needs.guard.outputs.has_cross == 'true' && needs.guard.outputs.has_zig == 'true'
+    if: needs.guard.outputs.ready == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Follow-up to [PR #6 discussion](https://github.com/code-yeongyu/c11-compiler-zig-omo/pull/6#discussion_r3144735038).

### cubic-dev-ai finding (quoted)

> The `guard` job in `phase3-verify.yml` checks for phase-3 scripts (`run-diff.sh`, `run-cross-docker.sh`) but does not unify the prerequisite check with `phase2/build.zig`. Downstream jobs individually gate on `has_zig`, yet the guard itself should short-circuit the entire workflow when `phase2/build.zig` is absent (pre-Phase-2). Once Phase 2 lands and `phase2/build.zig` exists, the guard should allow the workflow to proceed.

### What changed (v2 — per-job composites)

**Before (PR #6 original):**
```yaml
  zcc-vs-gcc:
    needs: guard
    if: needs.guard.outputs.has_diff == 'true' && needs.guard.outputs.has_zig == 'true'

  cross-compile-linux:
    needs: guard
    if: needs.guard.outputs.has_cross == 'true' && needs.guard.outputs.has_zig == 'true'
```

**After (this PR, v2):**
```yaml
  guard:
    outputs:
      has_diff: ${{ steps.detect.outputs.has_diff }}
      has_cross: ${{ steps.detect.outputs.has_cross }}
      has_zig: ${{ steps.detect.outputs.has_zig }}
      should_run_diff: ${{ steps.detect.outputs.should_run_diff }}
      should_run_cross: ${{ steps.detect.outputs.should_run_cross }}
    steps:
      - id: detect
        run: |
          ...
          if [ -f phase3/run-diff.sh ] && [ -f phase2/build.zig ]; then
            echo "should_run_diff=true" >> "$GITHUB_OUTPUT"
          else
            echo "should_run_diff=false" >> "$GITHUB_OUTPUT"
          fi
          if [ -f phase3/run-cross-docker.sh ] && [ -f phase2/build.zig ]; then
            echo "should_run_cross=true" >> "$GITHUB_OUTPUT"
          else
            echo "should_run_cross=false" >> "$GITHUB_OUTPUT"
          fi

  zcc-vs-gcc:
    needs: guard
    if: needs.guard.outputs.should_run_diff == 'true'

  cross-compile-linux:
    needs: guard
    if: needs.guard.outputs.should_run_cross == 'true'
```

### Behaviour matrix

| Files present | `should_run_diff` | `should_run_cross` | `zcc-vs-gcc` | `cross-compile-linux` |
|---|---|---|---|---|
| Nothing | false | false | **skip** | **skip** |
| `run-diff.sh` + `build.zig` only | true | false | **run** | **skip** |
| `run-cross-docker.sh` + `build.zig` only | false | true | **skip** | **run** |
| All three | true | true | **run** | **run** |

Each downstream job now gates only on its own required phase-3 script **plus** `phase2/build.zig` — no over-gating.

### Consistency check

- `phase1-c.yml` and `phase2-zig.yml` guard idioms were reviewed; no changes required there (they already use per-file `has_*` outputs correctly for their respective phases).

---

@cubic-dev-ai — please re-review.

Signed-off-by: [quick-engineer]
