### PR TITLE
[c11-ref-author] phase-1 / C11 ref cubic follow-up v1

### DIFF
--- a/phase1/c11-ref/005_thread_local.c
+++ b/phase1/c11-ref/005_thread_local.c
@@ -3,14 +3,14 @@
 #endif
 
 struct thread_local_result {
-    int supported;
+    int threads_supported;
     int main_value;
     int worker_value;
 };
 
-#if !defined(__STDC_NO_THREADS__)
 static _Thread_local int thread_local_counter;
 
+#if !defined(__STDC_NO_THREADS__)
 static int thread_local_worker(void *argument)
 {
     int *output = argument;
@@ -23,19 +23,22 @@ static int thread_local_worker(void *argument)
 
 struct thread_local_result thread_local_run(void)
 {
-#if defined(__STDC_NO_THREADS__)
-    return (struct thread_local_result){ .supported = 0, .main_value = 0, .worker_value = 0 };
-#else
-    thrd_t thread;
     int worker_value = 0;
     thread_local_counter = 5;
+#if !defined(__STDC_NO_THREADS__)
+    thrd_t thread;
     if (thrd_create(&thread, thread_local_worker, &worker_value) == thrd_success) {
         (void)thrd_join(thread, 0);
     }
+#endif
     return (struct thread_local_result){
-        .supported = 1,
+        .threads_supported =
+#if defined(__STDC_NO_THREADS__)
+            0,
+#else
+            1,
+#endif
         .main_value = thread_local_counter,
         .worker_value = worker_value,
     };
-#endif
 }

--- a/phase1/c11-ref/005_thread_local_test.c
+++ b/phase1/c11-ref/005_thread_local_test.c
@@ -15,10 +15,12 @@ int main(void)
     const struct thread_local_result result = thread_local_run();
 
     /* then */
-    assert(result.supported == threads_available);
+    assert(result.threads_supported == threads_available);
+    assert(result.main_value == 5);
     if (threads_available) {
-        assert(result.main_value == 5);
         assert(result.worker_value == 42);
+    } else {
+        assert(result.worker_value == 0);
     }
     C11_REF_OK();
 }

--- a/phase1/c11-ref/009_unicode_literals_test.c
+++ b/phase1/c11-ref/009_unicode_literals_test.c
@@ -4,6 +4,7 @@
 int main(void)
 {
     /* given */
+    const size_t expected_utf8_bytes = 7u;
     const size_t expected_utf16_units = 3u;
     const size_t expected_utf32_units = 2u;
 
@@ -11,7 +12,7 @@ int main(void)
     const struct unicode_literals_result result = unicode_literals_run();
 
     /* then */
-    assert(result.utf8_bytes > 5u);
+    assert(result.utf8_bytes == expected_utf8_bytes);
     assert(result.utf16_units == expected_utf16_units);
     assert(result.utf32_units == expected_utf32_units);
     assert(result.wide_units == 3u);

--- a/phase1/c11-ref/014_aligned_alloc.c
+++ b/phase1/c11-ref/014_aligned_alloc.c
@@ -11,10 +11,11 @@ struct aligned_alloc_result aligned_alloc_run(void)
     const size_t alignment = 32u;
     const size_t size = 64u;
     void *memory = aligned_alloc(alignment, size);
+    const int allocated = memory != 0;
     const int aligned = memory != 0 && ((uintptr_t)memory % alignment) == 0u;
     free(memory);
     return (struct aligned_alloc_result){
-        .allocated = memory != 0,
+        .allocated = allocated,
         .aligned = aligned,
     };
 }

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -57,6 +57,7 @@ DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d) $(TEST
 NEGATIVE_CFLAGS := $(CFLAGS) -pedantic-errors
 
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
+.NOTPARALLEL:
 
 all: check-gcc negative check-clang $(TESTS)
 

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -59,7 +59,7 @@ NEGATIVE_CFLAGS := $(CFLAGS) -pedantic-errors
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
 
 ifneq ($(filter clean,$(MAKECMDGOALS)),)
-check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression $(TESTS): clean
+.NOTPARALLEL:
 endif
 
 all: check-gcc negative check-clang $(TESTS)

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -112,7 +112,7 @@ check-negative-clang: $(NEGATIVE_SRCS)
 check-negative-filename-regression:
 	@mkdir -p $(BUILD_DIR)/negative
 	@src=negative/atomic_filename_regression.c; \
-	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.gcc.err; then \
+	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \
 	fi; \
@@ -124,13 +124,13 @@ check-negative-filename-regression:
 		printf '%s gcc path diagnostic no longer demonstrates filename keyword pollution\n' $$src >&2; \
 		exit 1; \
 	}; \
-	if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.gcc.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
+	if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
 		printf '%s gcc diagnostic matched keyword only from source content, expected no atomic keyword\n' $$src >&2; \
 		exit 1; \
 	fi; \
 	printf 'OK negative gcc: filename keyword regression rejected as expected\n'; \
 	if command -v $(CLANG) >/dev/null 2>&1; then \
-		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.clang.err; then \
+		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -142,7 +142,7 @@ check-negative-filename-regression:
 			printf '%s clang path diagnostic no longer demonstrates filename keyword pollution\n' $$src >&2; \
 			exit 1; \
 		}; \
-		if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.clang.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
+		if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
 			printf '%s clang diagnostic matched keyword only from source content, expected no atomic keyword\n' $$src >&2; \
 			exit 1; \
 		fi; \

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -54,6 +54,7 @@ TEST_CC ?= $(CC)
 LDLIBS ?= -lm
 COMMON_PREREQ := $(wildcard $(COMMON))
 DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d) $(TESTS:%=$(BUILD_DIR)/%.d)
+NEGATIVE_CFLAGS := $(CFLAGS) -pedantic-errors
 
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
 
@@ -79,7 +80,7 @@ check-negative-gcc: $(NEGATIVE_SRCS)
 		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(GCC) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.gcc.o < $$src 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
+		if $(GCC) $(NEGATIVE_CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.gcc.o < $$src 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
 			printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -99,7 +100,7 @@ check-negative-clang: $(NEGATIVE_SRCS)
 		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(CLANG) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.clang.o < $$src 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
+		if $(CLANG) $(NEGATIVE_CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.clang.o < $$src 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -113,11 +114,11 @@ check-negative-clang: $(NEGATIVE_SRCS)
 check-negative-filename-regression:
 	@mkdir -p $(BUILD_DIR)/negative
 	@src=negative/atomic_filename_regression.c; \
-	if $(GCC) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err; then \
+	if $(GCC) $(NEGATIVE_CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \
 	fi; \
-	if $(GCC) $(CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
+	if $(GCC) $(NEGATIVE_CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \
 	fi; \
@@ -131,11 +132,11 @@ check-negative-filename-regression:
 	fi; \
 	printf 'OK negative gcc: filename keyword regression rejected as expected\n'; \
 	if command -v $(CLANG) >/dev/null 2>&1; then \
-		if $(CLANG) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err; then \
+		if $(CLANG) $(NEGATIVE_CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		if $(CLANG) $(CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err; then \
+		if $(CLANG) $(NEGATIVE_CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -10,13 +10,13 @@ endif
 ifeq ($(filter command line environment,$(origin CFLAGS)),)
 CFLAGS ?= $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
 else
-override CFLAGS := $(CFLAGS) $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
+override CFLAGS := $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS) $(CFLAGS)
 endif
 
 ifeq ($(filter command line environment,$(origin LDFLAGS)),)
 LDFLAGS ?= $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
 else
-override LDFLAGS := $(LDFLAGS) $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
+override LDFLAGS := $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS) $(LDFLAGS)
 endif
 
 PROGRAMS := \

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -52,7 +52,8 @@ CLANG ?= clang
 BUILD_DIR := .build
 TEST_CC ?= $(CC)
 LDLIBS ?= -lm
-DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d)
+COMMON_PREREQ := $(wildcard $(COMMON))
+DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d) $(TESTS:%=$(BUILD_DIR)/%.d)
 
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
 
@@ -78,7 +79,7 @@ check-negative-gcc: $(NEGATIVE_SRCS)
 		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/$$name.gcc.o < $$src 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
+		if $(GCC) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.gcc.o < $$src 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
 			printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -98,7 +99,7 @@ check-negative-clang: $(NEGATIVE_SRCS)
 		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/$$name.clang.o < $$src 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
+		if $(CLANG) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/$$name.clang.o < $$src 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -112,11 +113,11 @@ check-negative-clang: $(NEGATIVE_SRCS)
 check-negative-filename-regression:
 	@mkdir -p $(BUILD_DIR)/negative
 	@src=negative/atomic_filename_regression.c; \
-	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err; then \
+	if $(GCC) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \
 	fi; \
-	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
+	if $(GCC) $(CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \
 	fi; \
@@ -130,11 +131,11 @@ check-negative-filename-regression:
 	fi; \
 	printf 'OK negative gcc: filename keyword regression rejected as expected\n'; \
 	if command -v $(CLANG) >/dev/null 2>&1; then \
-		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err; then \
+		if $(CLANG) $(CFLAGS) -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.stdin.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err; then \
+		if $(CLANG) $(CFLAGS) -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
@@ -149,21 +150,22 @@ check-negative-filename-regression:
 		printf 'OK negative clang: filename keyword regression rejected as expected\n'; \
 	fi
 
-$(BUILD_DIR)/gcc/%.c.o: %.c
+$(BUILD_DIR)/gcc/%.c.o: %.c $(COMMON_PREREQ)
 	@mkdir -p $(dir $@)
-	$(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -MMD -MP -MF $(@:.o=.d) -c $< -o $@
+	$(GCC) $(CFLAGS) -MMD -MP -MF $(@:.o=.d) -c $< -o $@
 
-$(BUILD_DIR)/clang/%.c.o: %.c
+$(BUILD_DIR)/clang/%.c.o: %.c $(COMMON_PREREQ)
 	@mkdir -p $(dir $@)
-	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -MMD -MP -MF $(@:.o=.d) -c $< -o $@
+	$(CLANG) $(CFLAGS) -MMD -MP -MF $(@:.o=.d) -c $< -o $@
 
 test: negative $(TESTS)
 	@set -e; for t in $(TESTS); do echo "==> $$t"; "./$$t" || exit 1; done
 
-%_test: %_test.c %.c
-	$(TEST_CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDLIBS)
+%_test: %_test.c %.c $(COMMON_PREREQ)
+	@mkdir -p $(BUILD_DIR)
+	$(TEST_CC) $(CFLAGS) -MMD -MP -MF $(BUILD_DIR)/$@.d $< -o $@ $(LDFLAGS) $(LDLIBS)
 
 clean:
 	rm -rf $(BUILD_DIR) $(TESTS) *.dSYM
 
--include $(DEPS)
+-include $(wildcard $(DEPS))

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -4,9 +4,11 @@ ifneq (,$(wildcard $(COMMON)))
 include $(COMMON)
 else
 CSTD ?= c11
-CFLAGS ?= -std=$(CSTD) -pedantic -Wall -Wextra -Werror -O2 -g
-LDFLAGS ?=
+CFLAGS_BASE ?= -std=$(CSTD) -pedantic -Wall -Wextra -Werror -O2 -g
 endif
+
+override CFLAGS += $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
+override LDFLAGS += $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
 
 PROGRAMS := \
 	001_generic_selection \

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -57,7 +57,10 @@ DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d) $(TEST
 NEGATIVE_CFLAGS := $(CFLAGS) -pedantic-errors
 
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
-.NOTPARALLEL:
+
+ifneq ($(filter clean,$(MAKECMDGOALS)),)
+check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression $(TESTS): clean
+endif
 
 all: check-gcc negative check-clang $(TESTS)
 

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -7,8 +7,17 @@ CSTD ?= c11
 CFLAGS_BASE ?= -std=$(CSTD) -pedantic -Wall -Wextra -Werror -O2 -g
 endif
 
-override CFLAGS += $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
-override LDFLAGS += $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
+ifeq ($(filter command line environment,$(origin CFLAGS)),)
+CFLAGS ?= $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
+else
+override CFLAGS := $(CFLAGS) $(CFLAGS_BASE) $(CFLAGS_PLATFORM) $(EXTRA_CFLAGS)
+endif
+
+ifeq ($(filter command line environment,$(origin LDFLAGS)),)
+LDFLAGS ?= $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
+else
+override LDFLAGS := $(LDFLAGS) $(LDFLAGS_BASE) $(LDFLAGS_PLATFORM) $(EXTRA_LDFLAGS)
+endif
 
 PROGRAMS := \
 	001_generic_selection \
@@ -43,6 +52,7 @@ CLANG ?= clang
 BUILD_DIR := .build
 TEST_CC ?= $(CC)
 LDLIBS ?= -lm
+DEPS := $(ALL_C:%=$(BUILD_DIR)/gcc/%.d) $(ALL_C:%=$(BUILD_DIR)/clang/%.d)
 
 .PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
 
@@ -59,7 +69,7 @@ check-clang:
 
 negative: check-negative-gcc check-negative-filename-regression
 
-check-negative-gcc:
+check-negative-gcc: $(NEGATIVE_SRCS)
 	@mkdir -p $(BUILD_DIR)/negative
 	@set -e; for src in $(NEGATIVE_SRCS); do \
 		name=$$(basename $$src .c); \
@@ -79,7 +89,7 @@ check-negative-gcc:
 		printf 'OK negative gcc: %s rejected as expected\n' $$src; \
 	done
 
-check-negative-clang:
+check-negative-clang: $(NEGATIVE_SRCS)
 	@mkdir -p $(BUILD_DIR)/negative
 	@set -e; for src in $(NEGATIVE_SRCS); do \
 		name=$$(basename $$src .c); \
@@ -141,11 +151,11 @@ check-negative-filename-regression:
 
 $(BUILD_DIR)/gcc/%.c.o: %.c
 	@mkdir -p $(dir $@)
-	$(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
+	$(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -MMD -MP -MF $(@:.o=.d) -c $< -o $@
 
 $(BUILD_DIR)/clang/%.c.o: %.c
 	@mkdir -p $(dir $@)
-	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $< -o $@
+	$(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -MMD -MP -MF $(@:.o=.d) -c $< -o $@
 
 test: negative $(TESTS)
 	@set -e; for t in $(TESTS); do echo "==> $$t"; "./$$t" || exit 1; done
@@ -155,3 +165,5 @@ test: negative $(TESTS)
 
 clean:
 	rm -rf $(BUILD_DIR) $(TESTS) *.dSYM
+
+-include $(DEPS)

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -42,7 +42,7 @@ BUILD_DIR := .build
 TEST_CC ?= $(CC)
 LDLIBS ?= -lm
 
-.PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang
+.PHONY: all test clean check-gcc check-clang negative check-negative-gcc check-negative-clang check-negative-filename-regression
 
 all: check-gcc negative check-clang $(TESTS)
 
@@ -55,7 +55,7 @@ check-clang:
 		printf 'clang not found; skipping clang syntax build\n'; \
 	fi
 
-negative: check-negative-gcc
+negative: check-negative-gcc check-negative-filename-regression
 
 check-negative-gcc:
 	@mkdir -p $(BUILD_DIR)/negative
@@ -63,13 +63,14 @@ check-negative-gcc:
 		name=$$(basename $$src .c); \
 		keyword='error'; \
 		if [ "$$name" = atomic_array ]; then keyword='atomic|_Atomic|array'; fi; \
+		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.gcc.o 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
+		if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/$$name.gcc.o < $$src 2>$(BUILD_DIR)/negative/$$name.gcc.err; then \
 			printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		grep -E "$$keyword" $(BUILD_DIR)/negative/$$name.gcc.err >/dev/null || { \
+		grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/$$name.gcc.err | grep -E "$$keyword" >/dev/null || { \
 			printf '%s gcc diagnostic missed expected constraint keyword\n' $$src >&2; \
 			exit 1; \
 		}; \
@@ -82,18 +83,55 @@ check-negative-clang:
 		name=$$(basename $$src .c); \
 		keyword='error'; \
 		if [ "$$name" = atomic_array ]; then keyword='atomic|_Atomic|array'; fi; \
+		if [ "$$name" = atomic_filename_regression ]; then keyword='expected|expression'; fi; \
 		if [ "$$name" = alignas_bitfield ]; then keyword='align|Alignas|bit-field|field'; fi; \
 		if [ "$$name" = vla_in_struct ]; then keyword='variable|variably|VLA|field|member'; fi; \
-		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/$$name.clang.o 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
+		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/$$name.clang.o < $$src 2>$(BUILD_DIR)/negative/$$name.clang.err; then \
 			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
 			exit 1; \
 		fi; \
-		grep -E "$$keyword" $(BUILD_DIR)/negative/$$name.clang.err >/dev/null || { \
+		grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/$$name.clang.err | grep -E "$$keyword" >/dev/null || { \
 			printf '%s clang diagnostic missed expected constraint keyword\n' $$src >&2; \
 			exit 1; \
 		}; \
 		printf 'OK negative clang: %s rejected as expected\n' $$src; \
 	done
+
+check-negative-filename-regression:
+	@mkdir -p $(BUILD_DIR)/negative
+	@src=negative/atomic_filename_regression.c; \
+	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
+		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
+		exit 1; \
+	fi; \
+	grep -E 'atomic|_Atomic|array' $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err >/dev/null || { \
+		printf '%s gcc path diagnostic no longer demonstrates filename keyword pollution\n' $$src >&2; \
+		exit 1; \
+	}; \
+	if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.gcc.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
+		printf '%s gcc diagnostic matched keyword only from source content, expected no atomic keyword\n' $$src >&2; \
+		exit 1; \
+	fi; \
+	printf 'OK negative gcc: filename keyword regression rejected as expected\n'; \
+	if command -v $(CLANG) >/dev/null 2>&1; then \
+		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.clang.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.clang.err; then \
+			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
+			exit 1; \
+		fi; \
+		if $(CLANG) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err; then \
+			printf '%s unexpectedly compiled with clang\n' $$src >&2; \
+			exit 1; \
+		fi; \
+		grep -E 'atomic|_Atomic|array' $(BUILD_DIR)/negative/atomic_filename_regression.path.clang.err >/dev/null || { \
+			printf '%s clang path diagnostic no longer demonstrates filename keyword pollution\n' $$src >&2; \
+			exit 1; \
+		}; \
+		if grep -E '(^| )error:|warning:' $(BUILD_DIR)/negative/atomic_filename_regression.clang.err | grep -E 'atomic|_Atomic|array' >/dev/null; then \
+			printf '%s clang diagnostic matched keyword only from source content, expected no atomic keyword\n' $$src >&2; \
+			exit 1; \
+		fi; \
+		printf 'OK negative clang: filename keyword regression rejected as expected\n'; \
+	fi
 
 $(BUILD_DIR)/gcc/%.c.o: %.c
 	@mkdir -p $(dir $@)

--- a/phase1/c11-ref/Makefile
+++ b/phase1/c11-ref/Makefile
@@ -100,6 +100,10 @@ check-negative-clang:
 check-negative-filename-regression:
 	@mkdir -p $(BUILD_DIR)/negative
 	@src=negative/atomic_filename_regression.c; \
+	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -x c -c - -o $(BUILD_DIR)/negative/atomic_filename_regression.gcc.o < $$src 2>$(BUILD_DIR)/negative/atomic_filename_regression.gcc.err; then \
+		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
+		exit 1; \
+	fi; \
 	if $(GCC) -std=c11 -pedantic -Wall -Wextra -Werror -c $$src -o $(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.o 2>$(BUILD_DIR)/negative/atomic_filename_regression.path.gcc.err; then \
 		printf '%s unexpectedly compiled with gcc\n' $$src >&2; \
 		exit 1; \

--- a/phase1/c11-ref/negative/atomic_filename_regression.c
+++ b/phase1/c11-ref/negative/atomic_filename_regression.c
@@ -1,0 +1,2 @@
+/* Filename intentionally contains "atomic"; diagnostic text should not. */
+int cubic_filename_regression = ;


### PR DESCRIPTION
{[c11-ref-author]}

## Summary
- Fix cubic-dev-ai PR #5 audit findings for aligned_alloc ownership, _Thread_local coverage, and UTF-8 byte-count strictness.
- Harden negative diagnostics so gcc/clang checks match diagnostic messages rather than source-file paths.
- Add `negative/atomic_filename_regression.c` to prove filename keywords cannot satisfy the negative harness.

## Cubic findings addressed
- r3144738361: `014_aligned_alloc.c` read-after-free.
- r3144738363: `_Thread_local` skipped when only `<threads.h>` is unavailable.
- r3144738365: weak UTF-8 byte count assertion.
- r3144784592: gcc negative diagnostic false positive from filename text.
- r3144784588: clang negative diagnostic false positive from filename text.

## Test Plan
- `make clean && make all && make test && make negative && make clean` in `phase1/c11-ref`
- `docker run --rm -v "$PWD:/work" -w /work gcc:14 bash -c 'cd phase1/c11-ref && make clean && make all && make test'`
- LSP diagnostics: only intentional negative-fixture compiler diagnostics remain.

## Merge contract
Do not merge until current-head gates are present:
- qa-tester: PASS
- verifier-deep: PASS
- reviewer-quality: APPROVE
- reviewer-ultrabrain: APPROVE
- cubic-dev-ai reviewed and all findings resolved or answered

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three C11 conformance gaps and hardens negative diagnostics to match compiler messages, not filenames. Makefile preserves required flags with caller overrides placed after defaults, restores -pedantic-errors for negative builds, adds depfiles for objects and tests, and limits serialization to clean-invoked goals.

- **Bug Fixes**
  - `_Thread_local`: Always exercise the keyword; report `threads_supported` separately when `<threads.h>` is missing. Tests assert `main_value == 5`; `worker_value == 42` with threads, else `0`.
  - `aligned_alloc`: Capture allocation state before `free` to avoid read-after-free; preserve `.allocated` and `.aligned`.
  - Unicode literals: Assert exact UTF-8 byte count (7).

- **Test Harness**
  - Negative tests compile via stdin (`-x c -c -`) and filter only `error:`/`warning:` lines before keyword matching.
  - Add `negative/atomic_filename_regression.c` and a `check-negative-filename-regression` target; build separate stdin vs path artifacts to prove filename keywords can’t satisfy checks.
  - Makefile: propagate base/platform flags with overrides placed last for `CFLAGS`/`LDFLAGS`; generate and include `.d` files for objects and `_test` binaries; restore `-pedantic-errors` via `NEGATIVE_CFLAGS` for negative recipes; serialize only when `clean` is invoked.

<sup>Written for commit 73ff59f988c84dee8458bac00733cf6b581de46d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

