### PR TITLE
[ci-engineer] phase-1 / CI: cubic-dev-ai PR #8 follow-up (4 findings + matrix.subproject regression check)

### DIFF
--- a/.github/workflows/phase1-c.yml
+++ b/.github/workflows/phase1-c.yml
@@ -17,8 +17,12 @@ on:
 # `head_ref` is set on pull_request events (the source branch); `ref_name` on
 # push events. Falling back across the two unifies the cancel group so a fresh
 # push to a feature branch also cancels the open PR's stale run.
+#
+# The source-repo qualifier (`pull_request.head.repo.full_name || repository`)
+# scopes the group per-fork so that a same-named branch on a contributor's fork
+# cannot cancel the upstream branch's run, and vice-versa.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/phase1-c.yml
+++ b/.github/workflows/phase1-c.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'phase1/**'
       - 'scripts/run-in-docker.sh'
+      - 'scripts/test-run-in-docker.sh'
       - '.github/workflows/phase1-c.yml'
   pull_request:
     paths:
       - 'phase1/**'
       - 'scripts/run-in-docker.sh'
+      - 'scripts/test-run-in-docker.sh'
       - '.github/workflows/phase1-c.yml'
 
 # Cancel in-flight runs for the same logical branch the moment a new push lands.
@@ -66,6 +68,9 @@ jobs:
             printf 'phase-1 sub-projects not yet authored — affected jobs will be skipped:\n'
             printf '  - %s\n' "${missing[@]}"
           fi
+      - name: scripts/run-in-docker.sh smoke
+        if: hashFiles('scripts/test-run-in-docker.sh') != ''
+        run: bash scripts/test-run-in-docker.sh
 
   c11-reference-native:
     name: c11-ref / native ${{ matrix.cc }} on ${{ matrix.os }}

--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -11,6 +11,10 @@ on:
       - 'phase2/**'
       - '.github/workflows/phase2-zig.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: phase-2 guard

--- a/.github/workflows/phase3-verify.yml
+++ b/.github/workflows/phase3-verify.yml
@@ -12,6 +12,10 @@ on:
       - 'phase2/**'
       - '.github/workflows/phase3-verify.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: phase-3 guard

--- a/docs/playbooks/ci-build-matrix.md
+++ b/docs/playbooks/ci-build-matrix.md
@@ -56,12 +56,15 @@ Why doom smoke is **not** in the docker matrix — bare `gcc:13/14` images don't
 
 ### macOS host, against gcc:14 in OrbStack
 
+The bare invocation runs the canonical default target sequence baked into [`scripts/run-in-docker.sh`](../../scripts/run-in-docker.sh) (`print-platform`, then `all`, then `test`); explicit targets after the subproject name override that default. `IMAGE=gcc:<tag>` selects the image and may appear anywhere in the argv (the optional `--` separator is purely cosmetic and never swallows the next argument). Make variables containing whitespace (such as `CFLAGS='-O2 -g -fsanitize=address'`) reach the container as a single argv element — they are not reparsed by an inner shell.
+
 ```bash
 orb start
-scripts/run-in-docker.sh c11-ref            # default targets: print-platform + all + test
+scripts/run-in-docker.sh c11-ref                                # default: print-platform + all + test
 scripts/run-in-docker.sh http2 all test smoke IO=epoll
-scripts/run-in-docker.sh doom  all test                  # no smoke in docker (Xvfb-less image)
-scripts/run-in-docker.sh c11-ref all test -- IMAGE=gcc:13   # alt image
+scripts/run-in-docker.sh doom  all test                         # no smoke in docker (Xvfb-less image)
+scripts/run-in-docker.sh c11-ref all test -- IMAGE=gcc:13       # alt image; -- is cosmetic
+scripts/run-in-docker.sh http2 all CFLAGS='-O2 -g -fsanitize=address'  # whitespace-safe
 ```
 
 ### macOS host, native (matches `*-native` jobs)
@@ -121,7 +124,7 @@ clean:
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `make: *** No rule to make target 'all'` in CI | Subproject Makefile not authored yet | The job emits a `::notice::` and exits 0 — that's expected during phase ramp-up. Once the Makefile lands, the gate flips. |
+| Subproject job shows `Skipped` (gray, neither red nor green) | `phase1/<sub>/Makefile` not authored yet | The `phase-1 guard` job sets `has_<sub>` outputs from Makefile presence; subproject jobs gate on `if: needs.guard.outputs.has_<sub> == 'true'` and are skipped when false. `make all` is never invoked in this state, so a missing-rule error never surfaces. Add `phase1/<sub>/Makefile` (and the matching path filter / output) to flip the gate. See `.github/workflows/phase1-c.yml` lines 29-64 for the guard logic and lines 66-167 for the per-subproject jobs. |
 | `make: *** No rule to make target 'print-platform'` | Subproject Makefile didn't include `../Makefile.common` | Add `include ../Makefile.common` at the top. **`make print-platform` is the canonical sentinel** — if it doesn't print `PLATFORM=… ARCH=… CC=… CFLAGS=…`, the include line is missing or broken. |
 | Build artefacts showing up as untracked in PRs | `OBJDIR` not under `phase1/<sub>/build/` | Either move builds into `build/`, or extend the root `.gitignore` (and document why in the PR). |
 | `liburing-dev not found` in docker | Tried to set `IO=io_uring` in the docker matrix | Don't — io_uring is exercised in the native ubuntu-latest cell; the docker matrix pins http2 to `IO=epoll`. |

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -54,13 +54,20 @@ fi
 
 echo "==> image=${IMAGE}  subproject=phase1/${SUB}  vars=[${MAKE_VARS[*]:-}]  targets=[${TARGETS[*]}]"
 
+# Build a shell-safe command line so whitespace in make variables (e.g.
+# CFLAGS='-O2 -g -fsanitize=address') survives the trip through docker.
+cmd="set -euxo pipefail; exec make"
+if [ "${#MAKE_VARS[@]}" -gt 0 ]; then
+  for v in "${MAKE_VARS[@]}"; do
+    cmd+=" $(printf '%q' "$v")"
+  done
+fi
+for t in "${TARGETS[@]}"; do
+  cmd+=" $(printf '%q' "$t")"
+done
+
 docker run --rm \
   -v "${ROOT}:/work" \
   -w "/work/phase1/${SUB}" \
   "${IMAGE}" \
-  bash -c "
-    set -euxo pipefail
-    for t in ${TARGETS[*]}; do
-      make ${MAKE_VARS[*]:-} \"\$t\"
-    done
-  "
+  bash -c "$cmd"

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -35,7 +35,7 @@ TARGETS=()
 MAKE_VARS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --)         shift ;;
+    --)         : ;;
     IMAGE=*)    IMAGE="${1#IMAGE=}" ;;
     *=*)        MAKE_VARS+=("$1") ;;
     *)          TARGETS+=("$1") ;;

--- a/scripts/test-run-in-docker.sh
+++ b/scripts/test-run-in-docker.sh
@@ -9,6 +9,9 @@
 # Regression coverage:
 #   - `-- IMAGE=...` separator must NOT swallow the next argument
 #     (cubic-dev-ai PR #8 finding scripts/run-in-docker.sh:38).
+#   - Make variables containing whitespace (e.g. CFLAGS='-O2 -g -fsanitize=address')
+#     must reach the container as a single argv element, not be reparsed by an
+#     inner shell (cubic-dev-ai PR #8 finding scripts/run-in-docker.sh:61).
 
 set -euo pipefail
 
@@ -40,6 +43,18 @@ sys.exit(0 if needle in parts else 1)
 PY
 }
 
+argv_contains() {
+  local needle="$1"
+  local file="$WORK/argv.bin"
+  python3 - "$file" "$needle" <<'PY'
+import sys
+path, needle = sys.argv[1], sys.argv[2]
+data = open(path, 'rb').read()
+parts = [p.decode() for p in data.split(b'\x00') if p != b'']
+sys.exit(0 if any(needle in part for part in parts) else 1)
+PY
+}
+
 argv_dump() {
   python3 - "$WORK/argv.bin" <<'PY'
 import sys
@@ -64,5 +79,16 @@ test_dash_dash_separator_preserves_image() {
 }
 
 test_dash_dash_separator_preserves_image
+
+test_make_vars_whitespace_preserved() {
+  run_under_stub c11-ref all "CFLAGS=-O2 -g -fsanitize=address"
+  # printf %q escapes spaces as \-space, so the value survives as a single
+  # shell token inside the bash -c string. We verify the bash -c argument
+  # contains the escaped form rather than being split into multiple words.
+  argv_contains 'CFLAGS=-O2\ -g\ -fsanitize=address' || fail 'CFLAGS value with spaces was reparsed into multiple argv elements'
+  echo 'ok: test_make_vars_whitespace_preserved'
+}
+
+test_make_vars_whitespace_preserved
 
 echo 'all run-in-docker tests passed'

--- a/scripts/test-run-in-docker.sh
+++ b/scripts/test-run-in-docker.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/test-run-in-docker.sh
+#
+# Smoke tests for scripts/run-in-docker.sh. The real docker binary is replaced
+# on PATH with a stub that just records its argv; we then assert the recorded
+# argv matches what we expect run-in-docker.sh to launch. No actual Docker
+# daemon is needed.
+#
+# Regression coverage:
+#   - `-- IMAGE=...` separator must NOT swallow the next argument
+#     (cubic-dev-ai PR #8 finding scripts/run-in-docker.sh:38).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat >"$WORK/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >"$DOCKER_STUB_ARGV"
+STUB
+chmod +x "$WORK/docker"
+
+run_under_stub() {
+  DOCKER_STUB_ARGV="$WORK/argv.bin" PATH="$WORK:$PATH" \
+    "$ROOT/scripts/run-in-docker.sh" "$@" >/dev/null
+}
+
+argv_has() {
+  local needle="$1"
+  local file="$WORK/argv.bin"
+  python3 - "$file" "$needle" <<'PY'
+import sys
+path, needle = sys.argv[1], sys.argv[2]
+data = open(path, 'rb').read()
+parts = [p.decode() for p in data.split(b'\x00') if p != b'']
+sys.exit(0 if needle in parts else 1)
+PY
+}
+
+argv_dump() {
+  python3 - "$WORK/argv.bin" <<'PY'
+import sys
+data = open(sys.argv[1], 'rb').read()
+parts = [p.decode() for p in data.split(b'\x00') if p != b'']
+for i, part in enumerate(parts):
+    print(f'{i}: {part!r}')
+PY
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "captured docker argv:" >&2
+  argv_dump >&2
+  exit 1
+}
+
+test_dash_dash_separator_preserves_image() {
+  run_under_stub c11-ref all -- IMAGE=gcc:13
+  argv_has 'gcc:13' || fail 'IMAGE=gcc:13 was dropped after the -- separator'
+  echo 'ok: test_dash_dash_separator_preserves_image'
+}
+
+test_dash_dash_separator_preserves_image
+
+echo 'all run-in-docker tests passed'


### PR DESCRIPTION
## Summary

Follow-up PR addressing the post-merge audit findings from cubic-dev-ai on PR #8. All 4 P2 findings plus the P1 `matrix.subproject` regression are now resolved.

## Cubic findings addressed

### 1. Concurrency key lacks fork qualifier — `pull/8#discussion_r3144771169`

> P2: Include the PR source repo in the concurrency key; using only `github.head_ref` lets same-named branches from different forks cancel each other's runs.

**Fixed:** Added `github.event.pull_request.head.repo.full_name || github.repository` to the `concurrency.group` key in all three phase workflows (`phase1-c.yml`, `phase2-zig.yml`, `phase3-verify.yml`). A branch named `feature-x` on a contributor's fork can no longer cancel the upstream `feature-x` run, and vice-versa.

Commit: `8c1dd3a`

### 2. `--` separator swallows next argument — `pull/8#discussion_r3144771177`

> P2: `--` currently skips the argument after it, so the documented `-- IMAGE=...` usage leaves `IMAGE` unchanged.

**Fixed:** Replaced the `--) shift ;;` arm with `--) : ;;` so the outer loop's `shift` consumes only the separator, preserving subsequent arguments. Regression-locked by `scripts/test-run-in-docker.sh` smoke test.

Commit: `88ca3bb`

### 3. `bash -c` reparses make variables, breaking quoted values — `pull/8#discussion_r3144771175`

> P2: Passing targets and make variables through `bash -c` reparses them, so quoted values like `CFLAGS='-O2 -g'` break and shell metacharacters can be executed.

**Fixed:** Replaced the inline `bash -c "... ${TARGETS[*]} ... ${MAKE_VARS[*]} ..."` interpolation with a command built using `printf '%q'` for every token. Each target and make variable is shell-quoted before entering the docker argv, so the inner bash reconstructs the original word exactly. A value like `CFLAGS='-O2 -g -fsanitize=address'` survives as a single token.

Regression-locked by a new test in `scripts/test-run-in-docker.sh` that asserts the captured `bash -c` string contains the `printf-%q`-escaped form of the CFLAGS value as a single contiguous token.

Commit: `f87a04d`

### 4. Playbook docs: guard-job skip behaviour — `pull/8#discussion_r3144771178`

> P2: This failure-mode row is misleading: missing Makefiles are skipped by the guard job, not surfaced as a `make all` error.

**Fixed:** Updated the "Common failure modes" table in `docs/playbooks/ci-build-matrix.md` to describe the actual symptom (`Skipped` job, grey) and cross-reference the guard job source in `.github/workflows/phase1-c.yml` lines 29-64 (guard logic) and 66-167 (per-subproject jobs).

Commit: `2d59cd5` (part 1)

### 5. Playbook docs: repro command default target — `pull/8#discussion_r3144771182`

> P2: This repro command is wrong: the script defaults to a non-existent `print-config` target, so the documented no-args form fails.

**Fixed:** The bare invocation section now documents the correct default target sequence (`print-platform`, `all`, `test`), notes that `--` is cosmetic and never swallows the next argument, and adds an example showing `CFLAGS='-O2 -g -fsanitize=address'` reaching the container intact.

Commit: `2d59cd5` (part 2)

## matrix.subproject regression check — `pull/8#discussion_r3144771168`

> P1: This job-level guard can't use `matrix.subproject`; GitHub evaluates `jobs.<job_id>.if` before expanding the matrix, so the docker matrix won't gate correctly.

**Status: ALREADY FIXED PRE-MERGE.** The original PR #8 was updated in commit `85c00db` to replace the broken `jobs.<id>.if` referencing `matrix.subproject` with a step-level `if:` inside the `gcc-in-docker` matrix job. The current `phase1-c.yml` at this branch uses:

```yaml
gcc-in-docker:
  if: |
    needs.guard.outputs.has_c11_ref == 'true' ||
    needs.guard.outputs.has_http2   == 'true' ||
    needs.guard.outputs.has_doom    == 'true'
```

at the **job** level (valid — `needs.guard.outputs` is available), and a per-cell `if:` at the **step** level using `matrix.subproject` (also valid — matrix context is available at step level). No regression; the P1 finding remains resolved.

## CI integration

The `phase1-c.yml` workflow now:
- Watches `scripts/test-run-in-docker.sh` in its path filters
- Runs `bash scripts/test-run-in-docker.sh` in the `guard` job when the file exists

This ensures the smoke tests are exercised on every PR that touches the script.

Commit: `7b866d5`

## Verification

- `actionlint .github/workflows/*.yml` — clean
- `bash scripts/test-run-in-docker.sh` — both tests pass

Re-requesting cubic-dev-ai review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four P2 findings from cubic-dev-ai PR #8, keeps the P1 matrix guard correct, and makes CI concurrency fork-safe across all phase workflows. Adds a smoke test for `scripts/run-in-docker.sh` and updates the playbook docs.

- **Bug Fixes**
  - Fork-safe concurrency keys in `phase1-c.yml`, `phase2-zig.yml`, `phase3-verify.yml` with cancel-in-progress.
  - `--` separator no longer swallows the next arg; `IMAGE=gcc:<tag>` now works as documented.
  - Preserve make-variable quoting via `printf '%q'` so values like `CFLAGS='-O2 -g -fsanitize=address'` survive intact.
  - Playbook docs: correct guard-job skip behavior and default target sequence; clarify `--` is cosmetic and variables are whitespace-safe.
  - P1 check: `matrix.subproject` gating remains at step level (no change required).

- **New Features**
  - Added `scripts/test-run-in-docker.sh` smoke tests (stubs `docker`, validates argv).
  - Wired into `phase1-c.yml` guard job and path filters so changes to the script run the smoke test in CI.

<sup>Written for commit 7b866d52ac52ad8fbd7192f761f2481e0a0ee56a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

