### PR TITLE
[writing-engineer] phase-2 / docs — Zig build discipline + async patterns + C11 mapping

### DIFF
--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -2,7 +2,7 @@
 
 This playbook is the **contract** every `phase2/zcc/` component must satisfy. CI ([`.github/workflows/phase2-zig.yml`](../../.github/workflows/phase2-zig.yml)) calls these targets directly. If your `build.zig` is missing one, your job will fail.
 
-## Target contract
+## 1. Target contract
 
 | Target | When CI calls it | What it must do |
 |---|---|---|
@@ -15,7 +15,7 @@ This playbook is the **contract** every `phase2/zcc/` component must satisfy. CI
 
 A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target must exercise the full pipeline: lex → parse → sema → codegen → assemble → link → run.
 
-## build.zig skeleton
+## 2. build.zig skeleton
 
 ```zig
 const std = @import("std");
@@ -89,7 +89,7 @@ pub fn build(b: *std.Build) void {
 }
 ```
 
-## Directory layout
+## 3. Directory layout
 
 ```
 phase2/zcc/
@@ -113,7 +113,7 @@ phase2/zcc/
 
 Unit tests live **inside** the source files they test, using Zig's `test` blocks. Integration tests live in `tests/integration/` as standalone `.zig` files that import from `src/`. Smoke tests live in `tests/smoke/` as `.c` files plus a `runner.zig` that drives `zcc` and verifies output.
 
-## Test discipline
+## 4. Test discipline
 
 ### Unit tests (co-located)
 
@@ -168,7 +168,7 @@ test "smoke: hello.c compiles and runs" {
 }
 ```
 
-## CI matrix (`.github/workflows/phase2-zig.yml`)
+## 5. CI matrix (`.github/workflows/phase2-zig.yml`)
 
 | Job | Runner | Zig version | Optimize |
 |---|---|---|---|
@@ -180,7 +180,7 @@ test "smoke: hello.c compiles and runs" {
 
 Every job runs `zig build`, `zig build test`, `zig build smoke`, `zig build fmt`, and `zig build lint` in sequence. Any non-zero exit fails the job.
 
-## Reproducing CI locally
+## 6. Reproducing CI locally
 
 ### macOS host
 
@@ -202,7 +202,7 @@ zig build -Doptimize=ReleaseFast test smoke
 scripts/run-in-docker.sh phase2 test smoke fmt lint
 ```
 
-## Common failure modes
+## 7. Common failure modes
 
 | Symptom | Cause | Fix |
 |---|---|---|
@@ -213,7 +213,7 @@ scripts/run-in-docker.sh phase2 test smoke fmt lint
 | Tests pass on macOS but fail on Linux (or vice versa) | Platform-specific code path (e.g. kqueue vs epoll) | Gate the test with `if (builtin.os.tag != .linux) return error.SkipZigTest;` or add a Linux-specific fixture. |
 | `build.zig.zon` has dependencies | Violates the "zero external deps" rule | Remove the dependency and reimplement with std lib. If you believe the dependency is essential, amend ADR-0001 first. |
 
-## Reviewer-quality (`{[reviewer-quality]}`) review checklist
+## 8. Reviewer-quality (`{[reviewer-quality]}`) review checklist
 
 When reviewing a Phase 2 PR, check:
 
@@ -226,3 +226,13 @@ When reviewing a Phase 2 PR, check:
 7. `build.zig.zon` has zero dependencies.
 
 If 1–7 pass, comment `reviewer-quality: APPROVE` on the PR. If anything fails, leave a `{[reviewer-quality]}` change-request comment with concrete diffs or log excerpts.
+
+## 9. References
+
+| Source | URL |
+|---|---|
+| Zig 0.16.0 Release Notes | https://ziglang.org/download/0.16.0/release-notes.html |
+| Zig Language Reference | https://ziglang.org/documentation/0.16.0/ |
+| `std.Build` API | https://github.com/ziglang/zig/blob/master/lib/std/Build.zig |
+| `std.Build.Step.Compile` | https://github.com/ziglang/zig/blob/master/lib/std/Build/Step/Compile.zig |
+| ADR-0001 — Toolchain & target matrix | ../../decisions/0001-stack-and-toolchain.md |

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -73,12 +73,15 @@ pub fn build(b: *std.Build) void {
 
     // --- lint (ast-check) ---
     const lint_step = b.step("lint", "Run ast-check on all .zig files");
-    const lint_src = b.addSystemCommand(&.{"zig", "ast-check"});
-    lint_src.addFileArg(b.path("src/main.zig"));
-    lint_step.dependOn(&lint_src.step);
-    const lint_tests = b.addSystemCommand(&.{"zig", "ast-check"});
-    lint_tests.addFileArg(b.path("tests/smoke/runner.zig"));
-    lint_step.dependOn(&lint_tests.step);
+    // NOTE: In a real build.zig, iterate over all .zig files under src/ and tests/
+    // using std.fs.walk or a manually-maintained file list. The skeleton below
+    // shows the pattern for two representative files; expand to full glob in production.
+    const src_files = &.{ "src/main.zig", "src/lexer.zig", "src/parser.zig" };
+    for (src_files) |src_file| {
+        const lint = b.addSystemCommand(&.{"zig", "ast-check"});
+        lint.addFileArg(b.path(src_file));
+        lint_step.dependOn(&lint.step);
+    }
 
     // --- clean ---
     const clean_step = b.step("clean", "Remove build artefacts");

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -11,7 +11,7 @@ This playbook is the **contract** every `phase2/zcc/` component must satisfy. CI
 | `zig build smoke` | every job | End-to-end smoke test: compile a small C file with `zcc` and run the resulting binary. |
 | `zig build fmt` | every job | Verify `zig fmt` produces no changes. |
 | `zig build lint` | every job | Run `zig ast-check` on every `.zig` file in `phase2/zcc/src/` and `phase2/zcc/tests/`. |
-| `zig build clean` | not in CI, expected for local hygiene | Remove `zig-cache/`, `zig-out/`, and any generated artefacts. |
+| `zig build clean` | docker subset only; local hygiene otherwise | Remove `zig-cache/`, `zig-out/`, and any generated artefacts. |
 
 A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target must exercise the full pipeline: lex → parse → sema → codegen → assemble → link → run.
 

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -25,20 +25,26 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // --- compiler executable ---
-    const exe = b.addExecutable(.{
-        .name = "zcc",
+    const mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    const exe = b.addExecutable(.{
+        .name = "zcc",
+        .root_module = mod,
     });
     b.installArtifact(exe);
 
     // --- unit tests ---
     const test_step = b.step("test", "Run unit tests");
-    const src_tests = b.addTest(.{
+    const test_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    const src_tests = b.addTest(.{
+        .root_module = test_mod,
     });
     const run_src_tests = b.addRunArtifact(src_tests);
     test_step.dependOn(&run_src_tests.step);
@@ -54,11 +60,14 @@ pub fn build(b: *std.Build) void {
     smoke_step.dependOn(&smoke_run.step);
 
     // Run the compiled smoke binary
-    const run_smoke = b.addRunArtifact(b.addExecutable(.{
-        .name = "smoke-runner",
+    const runner_mod = b.createModule(.{
         .root_source_file = b.path("tests/smoke/runner.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    const run_smoke = b.addRunArtifact(b.addExecutable(.{
+        .name = "smoke-runner",
+        .root_module = runner_mod,
     }));
     run_smoke.addFileArg(smoke_out);
     smoke_step.dependOn(&run_smoke.step);
@@ -181,7 +190,7 @@ test "smoke: hello.c compiles and runs" {
 | `zcc / macos release` | macos-latest | 0.16.0 | `-Doptimize=ReleaseFast` |
 | `zcc / docker gcc:14` | ubuntu-latest | 0.16.0 (installed in container) | `-Doptimize=ReleaseFast` |
 
-Every job runs `zig build`, `zig build test`, `zig build smoke`, `zig build fmt`, and `zig build lint` in sequence. Any non-zero exit fails the job.
+Host jobs (ubuntu-latest, macos-latest) run the full suite: `zig build`, `zig build test`, `zig build smoke`, `zig build fmt`, and `zig build lint`. The docker job runs a fast subset (`clean`, `test`, `smoke`) because container startup dominates wall-clock time and `fmt`/`lint` are already gated on host jobs. Any non-zero exit fails the job.
 
 ## 6. Reproducing CI locally
 
@@ -202,7 +211,7 @@ zig build -Doptimize=ReleaseFast test smoke
 ### Docker (gcc:14 image, for Linux-only validation)
 
 ```bash
-scripts/run-in-docker.sh phase2 test smoke fmt lint
+IMAGE=gcc:14 bash scripts/run-in-docker-phase2.sh zcc clean test smoke
 ```
 
 ## 7. Common failure modes

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -13,7 +13,7 @@ This playbook is the **contract** every `phase2/zcc/` component must satisfy. CI
 | `zig build lint` | every job | Run `zig ast-check` on every `.zig` file in `phase2/zcc/src/` and `phase2/zcc/tests/`. |
 | `zig build clean` | docker subset only; local hygiene otherwise | Remove `zig-cache/`, `zig-out/`, and any generated artefacts. |
 
-A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target must exercise the full pipeline: lex → parse → sema → codegen → assemble → link → run.
+A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target's coverage grows by Wave: Wave 0 dumps tokens (`-E`); Wave 1 adds AST printing; Wave 2-3 add semantic checks; Wave 4+ exercises codegen → link → run. By Wave 10, smoke must run the full pipeline (lex → parse → sema → codegen → assemble → link → run).
 
 ## 2. build.zig skeleton
 

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -1,6 +1,6 @@
 # Playbook — Phase-2 Zig Build Discipline
 
-This playbook is the **contract** every `phase2/` component must satisfy. CI ([`.github/workflows/phase2-zig.yml`](../../.github/workflows/phase2-zig.yml)) calls these targets directly. If your `build.zig` is missing one, your job will fail.
+This playbook is the **contract** every `phase2/zcc/` component must satisfy. CI ([`.github/workflows/phase2-zig.yml`](../../.github/workflows/phase2-zig.yml)) calls these targets directly. If your `build.zig` is missing one, your job will fail.
 
 ## Target contract
 
@@ -10,7 +10,7 @@ This playbook is the **contract** every `phase2/` component must satisfy. CI ([`
 | `zig build test` | every job | Run the full test suite; **non-zero exit on any failure**. |
 | `zig build smoke` | every job | End-to-end smoke test: compile a small C file with `zcc` and run the resulting binary. |
 | `zig build fmt` | every job | Verify `zig fmt` produces no changes. |
-| `zig build lint` | every job | Run `zig ast-check` on every `.zig` file in `phase2/src/` and `phase2/tests/`. |
+| `zig build lint` | every job | Run `zig ast-check` on every `.zig` file in `phase2/zcc/src/` and `phase2/zcc/tests/`. |
 | `zig build clean` | not in CI, expected for local hygiene | Remove `zig-cache/`, `zig-out/`, and any generated artefacts. |
 
 A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target must exercise the full pipeline: lex → parse → sema → codegen → assemble → link → run.
@@ -89,7 +89,7 @@ pub fn build(b: *std.Build) void {
 ## Directory layout
 
 ```
-phase2/
+phase2/zcc/
   build.zig           # this playbook applies here
   build.zig.zon       # zero external deps — only std lib
   src/

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -47,7 +47,7 @@ pub fn build(b: *std.Build) void {
     const smoke_step = b.step("smoke", "End-to-end smoke test");
     const smoke_run = b.addRunArtifact(exe);
     smoke_run.addArg("--target");
-    smoke_run.addArg(b.fmt("{s}", .{@tagName(target.getCpuArch())}));
+    smoke_run.addArg(b.fmt("{s}", .{@tagName(target.result.cpu.arch)}));
     smoke_run.addFileArg(b.path("tests/smoke/hello.c"));
     smoke_run.addArg("-o");
     const smoke_out = smoke_run.addOutputFileArg("smoke");
@@ -72,16 +72,19 @@ pub fn build(b: *std.Build) void {
     fmt_step.dependOn(&fmt.step);
 
     // --- lint (ast-check) ---
-    const lint_step = b.step("lint", "Run ast-check");
-    const lint = b.addSystemCommand(&.{"zig", "ast-check"});
-    lint.addFileArg(b.path("src/main.zig"));
-    lint_step.dependOn(&lint.step);
+    const lint_step = b.step("lint", "Run ast-check on all .zig files");
+    const lint_src = b.addSystemCommand(&.{"zig", "ast-check"});
+    lint_src.addFileArg(b.path("src/main.zig"));
+    lint_step.dependOn(&lint_src.step);
+    const lint_tests = b.addSystemCommand(&.{"zig", "ast-check"});
+    lint_tests.addFileArg(b.path("tests/smoke/runner.zig"));
+    lint_step.dependOn(&lint_tests.step);
 
     // --- clean ---
     const clean_step = b.step("clean", "Remove build artefacts");
-    const clean = b.addRemoveDirTree(b.path("zig-cache"));
-    clean_step.dependOn(&clean.step);
-    const clean_out = b.addRemoveDirTree(b.path("zig-out"));
+    const clean_cache = b.addSystemCommand(&.{"rm", "-rf", "zig-cache"});
+    clean_step.dependOn(&clean_cache.step);
+    const clean_out = b.addSystemCommand(&.{"rm", "-rf", "zig-out"});
     clean_step.dependOn(&clean_out.step);
 }
 ```

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -1,0 +1,225 @@
+# Playbook — Phase-2 Zig Build Discipline
+
+This playbook is the **contract** every `phase2/` component must satisfy. CI ([`.github/workflows/phase2-zig.yml`](../../.github/workflows/phase2-zig.yml)) calls these targets directly. If your `build.zig` is missing one, your job will fail.
+
+## Target contract
+
+| Target | When CI calls it | What it must do |
+|---|---|---|
+| `zig build` | every job | Compile the compiler and all supporting tools. |
+| `zig build test` | every job | Run the full test suite; **non-zero exit on any failure**. |
+| `zig build smoke` | every job | End-to-end smoke test: compile a small C file with `zcc` and run the resulting binary. |
+| `zig build fmt` | every job | Verify `zig fmt` produces no changes. |
+| `zig build lint` | every job | Run `zig ast-check` on every `.zig` file in `phase2/src/` and `phase2/tests/`. |
+| `zig build clean` | not in CI, expected for local hygiene | Remove `zig-cache/`, `zig-out/`, and any generated artefacts. |
+
+A `build.zig` **must** define `test`, `smoke`, `fmt`, and `lint`. `clean` is optional but strongly recommended. The `smoke` target must exercise the full pipeline: lex → parse → sema → codegen → assemble → link → run.
+
+## build.zig skeleton
+
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // --- compiler executable ---
+    const exe = b.addExecutable(.{
+        .name = "zcc",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+
+    // --- unit tests ---
+    const test_step = b.step("test", "Run unit tests");
+    const src_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const run_src_tests = b.addRunArtifact(src_tests);
+    test_step.dependOn(&run_src_tests.step);
+
+    // --- smoke test ---
+    const smoke_step = b.step("smoke", "End-to-end smoke test");
+    const smoke_run = b.addRunArtifact(exe);
+    smoke_run.addArg("--target");
+    smoke_run.addArg(b.fmt("{s}", .{@tagName(target.getCpuArch())}));
+    smoke_run.addFileArg(b.path("tests/smoke/hello.c"));
+    smoke_run.addArg("-o");
+    const smoke_out = smoke_run.addOutputFileArg("smoke");
+    smoke_step.dependOn(&smoke_run.step);
+
+    // Run the compiled smoke binary
+    const run_smoke = b.addRunArtifact(b.addExecutable(.{
+        .name = "smoke-runner",
+        .root_source_file = b.path("tests/smoke/runner.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
+    run_smoke.addFileArg(smoke_out);
+    smoke_step.dependOn(&run_smoke.step);
+
+    // --- fmt check ---
+    const fmt_step = b.step("fmt", "Check formatting");
+    const fmt = b.addFmt(.{
+        .paths = &.{ "src", "tests" },
+        .check = true,
+    });
+    fmt_step.dependOn(&fmt.step);
+
+    // --- lint (ast-check) ---
+    const lint_step = b.step("lint", "Run ast-check");
+    const lint = b.addSystemCommand(&.{"zig", "ast-check"});
+    lint.addFileArg(b.path("src/main.zig"));
+    lint_step.dependOn(&lint.step);
+
+    // --- clean ---
+    const clean_step = b.step("clean", "Remove build artefacts");
+    const clean = b.addRemoveDirTree(b.path("zig-cache"));
+    clean_step.dependOn(&clean.step);
+    const clean_out = b.addRemoveDirTree(b.path("zig-out"));
+    clean_step.dependOn(&clean_out.step);
+}
+```
+
+## Directory layout
+
+```
+phase2/
+  build.zig           # this playbook applies here
+  build.zig.zon       # zero external deps — only std lib
+  src/
+    main.zig          # driver: CLI parsing, pipeline orchestration
+    lexer.zig         # C11 lexer
+    parser.zig        # recursive descent parser
+    sema.zig          # semantic analysis
+    ir.zig            # intermediate representation (optional)
+    codegen.zig       # assembly emission
+    assembler.zig     # internal assembler (optional)
+    linker.zig        # internal linker (optional)
+  tests/
+    unit/             # per-module unit tests (co-located in src/ via `test` blocks)
+    integration/      # multi-module integration tests
+    smoke/            # end-to-end: C → zcc → binary → run
+    fixtures/         # .c files used by integration and smoke tests
+```
+
+Unit tests live **inside** the source files they test, using Zig's `test` blocks. Integration tests live in `tests/integration/` as standalone `.zig` files that import from `src/`. Smoke tests live in `tests/smoke/` as `.c` files plus a `runner.zig` that drives `zcc` and verifies output.
+
+## Test discipline
+
+### Unit tests (co-located)
+
+Every public function in `src/` must have at least one `test` block. The block name should match the function:
+
+```zig
+pub fn tokenizeScalar(comptime T: type, buffer: []const T, delimiter: T) std.mem.TokenIterator(T, .scalar) {
+    return std.mem.tokenizeScalar(T, buffer, delimiter);
+}
+
+test "tokenizeScalar splits on delimiter" {
+    // given a buffer with two words separated by a space
+    const buffer = "hello world";
+
+    // when we tokenize on space
+    var it = tokenizeScalar(u8, buffer, ' ');
+
+    // then we get two tokens
+    try std.testing.expectEqualStrings("hello", it.next().?);
+    try std.testing.expectEqualStrings("world", it.next().?);
+    try std.testing.expect(it.next() == null);
+}
+```
+
+### Integration tests
+
+Integration tests verify that multiple modules compose correctly. They live in `tests/integration/` and are compiled as separate test binaries in `build.zig`:
+
+```zig
+const integration_test = b.addTest(.{
+    .root_source_file = b.path("tests/integration/lexer_parser.zig"),
+    .target = target,
+    .optimize = optimize,
+});
+```
+
+### Smoke tests
+
+Smoke tests verify the full compiler pipeline. Each smoke test is a `.c` file in `tests/smoke/` that exercises a specific C11 feature. The `runner.zig` compiles it with `zcc`, runs the resulting binary, and checks exit code and stdout:
+
+```zig
+test "smoke: hello.c compiles and runs" {
+    // given a minimal C program that prints "hello"
+    const c_src = "tests/smoke/hello.c";
+
+    // when we compile it with zcc and run the binary
+    const output = try runZccAndExec(allocator, c_src);
+
+    // then the output is exactly "hello\n" and exit code is 0
+    try std.testing.expectEqualStrings("hello\n", output.stdout);
+    try std.testing.expectEqual(0, output.exit_code);
+}
+```
+
+## CI matrix (`.github/workflows/phase2-zig.yml`)
+
+| Job | Runner | Zig version | Optimize |
+|---|---|---|---|
+| `zcc / native debug` | ubuntu-latest | 0.16.0 | `-Doptimize=Debug` |
+| `zcc / native release` | ubuntu-latest | 0.16.0 | `-Doptimize=ReleaseFast` |
+| `zcc / macos debug` | macos-latest | 0.16.0 | `-Doptimize=Debug` |
+| `zcc / macos release` | macos-latest | 0.16.0 | `-Doptimize=ReleaseFast` |
+| `zcc / docker gcc:14` | ubuntu-latest | 0.16.0 (installed in container) | `-Doptimize=ReleaseFast` |
+
+Every job runs `zig build`, `zig build test`, `zig build smoke`, `zig build fmt`, and `zig build lint` in sequence. Any non-zero exit fails the job.
+
+## Reproducing CI locally
+
+### macOS host
+
+```bash
+zig build -Doptimize=Debug test smoke fmt lint
+zig build -Doptimize=ReleaseFast test smoke
+```
+
+### Linux host
+
+```bash
+zig build -Doptimize=Debug test smoke fmt lint
+zig build -Doptimize=ReleaseFast test smoke
+```
+
+### Docker (gcc:14 image, for Linux-only validation)
+
+```bash
+scripts/run-in-docker.sh phase2 test smoke fmt lint
+```
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `zig build` fails with `error: no member named 'addExecutable' in 'Build'` | Using Zig 0.13 or older API | Upgrade to Zig 0.16.0. The `Build` API changed significantly between 0.13 and 0.16. |
+| `zig build test` passes but `zig build smoke` fails | Smoke fixture `.c` file uses a C11 feature not yet implemented | Skip that fixture in `build.zig` (conditional `smoke_step.dependOn`) and open a tracking issue. Do not delete the fixture. |
+| `zig build fmt` fails | Unformatted `.zig` file | Run `zig fmt src/ tests/` locally and commit the result. |
+| `zig build lint` fails | `zig ast-check` reports a syntax error | Fix the syntax error. `ast-check` is stricter than `zig build` for some edge cases. |
+| Tests pass on macOS but fail on Linux (or vice versa) | Platform-specific code path (e.g. kqueue vs epoll) | Gate the test with `if (builtin.os.tag != .linux) return error.SkipZigTest;` or add a Linux-specific fixture. |
+| `build.zig.zon` has dependencies | Violates the "zero external deps" rule | Remove the dependency and reimplement with std lib. If you believe the dependency is essential, amend ADR-0001 first. |
+
+## Reviewer-quality (`{[reviewer-quality]}`) review checklist
+
+When reviewing a Phase 2 PR, check:
+
+1. `build.zig` defines `test`, `smoke`, `fmt`, and `lint`.
+2. All targets succeed locally on **both** macOS-native and `gcc:14` docker.
+3. No build artefacts committed (`git ls-files | rg 'zig-cache|zig-out' returns empty`).
+4. Tests are real: unit tests **and** an end-to-end smoke test, no mocks unless physically unavoidable, given/when/then in the body.
+5. Every cell of the CI matrix above is green.
+6. PR body links the relevant Phase 2 tracking issue and includes a Test Plan section per the team charter.
+7. `build.zig.zon` has zero dependencies.
+
+If 1–7 pass, comment `reviewer-quality: APPROVE` on the PR. If anything fails, leave a `{[reviewer-quality]}` change-request comment with concrete diffs or log excerpts.

--- a/docs/playbooks/zig-build-discipline.md
+++ b/docs/playbooks/zig-build-discipline.md
@@ -155,10 +155,14 @@ test "tokenizeScalar splits on delimiter" {
 Integration tests verify that multiple modules compose correctly. They live in `tests/integration/` and are compiled as separate test binaries in `build.zig`:
 
 ```zig
-const integration_test = b.addTest(.{
+const integration_module = b.createModule(.{
     .root_source_file = b.path("tests/integration/lexer_parser.zig"),
     .target = target,
     .optimize = optimize,
+});
+const integration_test = b.addTest(.{
+    .name = "integration_test",
+    .root_module = integration_module,
 });
 ```
 

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -78,7 +78,7 @@ void foo(int n) {
 
 ```zig
 // Zig equivalent: allocator or stack slice
-fn foo(n: usize) void {
+fn foo(n: usize) !void {
     var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
     const arr = try allocator.alloc(i32, n);
@@ -234,7 +234,7 @@ fn abs(x: anytype) @TypeOf(x) {
 | `memset` | `@memset` | |
 | `memcmp` | `std.mem.eql` or `std.mem.compare` | |
 | `strlen` | `std.mem.len` or `std.mem.sliceTo` | |
-| `strcpy` / `strncpy` | `std.mem.copy` | Zig copies are always bounded. |
+| `strcpy` / `strncpy` | `@memcpy` or `std.mem.copyForwards` | `@memcpy` is a compile-time builtin (no overlap allowed). `std.mem.copyForwards` allows overlap if dest <= source. |
 | `strcat` / `strncat` | `std.mem.concat` | |
 
 ### stdlib.h

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -40,7 +40,7 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 | `struct S { ... }` | `const S = struct { ... }` | Zig structs are namespaced. Use `extern struct` for C ABI compatibility. |
 | `union U { ... }` | `const U = union { ... }` | Use `extern union` for C ABI. For tagged unions, use `union(enum) { ... }`. |
 | `enum E { A, B }` | `const E = enum(c_int) { A, B }` | C enum compatible integer type is implementation/ABI/enumerator dependent. `enum(c_int)` is acceptable for common ABI interop but NOT a complete C11 sema rule. |
-| `typedef` | `const` alias or `usingnamespace` | Zig prefers `const MyInt = i32;` over `typedef`. |
+| `typedef` | `const` alias | Zig prefers `const MyInt = i32;` over `typedef`. `usingnamespace` was removed in Zig 0.16; use explicit imports. |
 | `T (*f)(U, V)` | `*const fn (U, V) T` | Function pointer. Note Zig fn pointers are non-null; use `?*const fn(...)` for nullable. |
 
 ### Type qualifiers and attributes
@@ -52,7 +52,7 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 | `restrict` | `noalias` | Zig `noalias` on pointer parameters. |
 | `_Alignas(N)` | `align(N)` | Zig `align(N)` on types and variables. |
 | `_Alignof(T)` | `@alignOf(T)` | Direct match. |
-| `_Static_assert(E, msg)` | `@compileLog` or `comptime assert` | Use `comptime { assert(E); }` for compile-time assertions. |
+| `_Static_assert(E, msg)` | `comptime assert` | Use `comptime { assert(E); }` for compile-time assertions. `@compileLog` does not halt compilation and is not a substitute. |
 
 ## 2. Memory and storage
 
@@ -79,7 +79,7 @@ void foo(int n) {
 ```zig
 // Zig equivalent: allocator or stack slice
 fn foo(n: usize) void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
     const arr = try allocator.alloc(i32, n);
     defer allocator.free(arr);

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -19,7 +19,7 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 | `_Bool` | `bool` | Zig `bool` is 1 bit logically, 1 byte physically. C `_Bool` is 1 byte. |
 | `float` | `f32` | IEEE 754 single precision. |
 | `double` | `f64` | IEEE 754 double precision. |
-| `long double` | `f80` or `f128` | Platform-dependent. On x86_64 it is 80-bit extended precision (`f80`). On arm64 it is `f128`. Match the target ABI. |
+| `long double` | `f80` or `f64` or `f128` | Platform-dependent. On x86_64 it is 80-bit extended precision (`f80`). On Darwin arm64 it is `f64` (same as `double`). On Linux arm64 (AAPCS64) it is `f128`. Match the target ABI. |
 | `float _Complex` | `std.math.complex.Complex(f32)` | Zig std lib provides complex numbers. |
 | `double _Complex` | `std.math.complex.Complex(f64)` | |
 | `_Atomic T` | `std.atomic.Value(T)` | For scalar `T`. For structs, use `std.Thread.Mutex` or align to cache line and use atomic builtins. |
@@ -34,12 +34,12 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 |---|---|---|
 | `T*` | `*T` or `*allowzero T` | Zig `*T` is a non-null, non-optional single-item pointer. For C `NULL`, use `?*T`. For zero-as-valid (e.g. x86 real mode), use `*allowzero T`. |
 | `const T*` | `*const T` | Direct match. |
-| `T[]` (incomplete array) | `[]T` | Zig slice is ptr+len. C incomplete array is just a pointer. |
+| `T[]` (incomplete array) | `[*]T` or `[0]T` | C array parameters decay to pointers; external incomplete arrays carry no length. Use `[*]T` (many-pointer) for general C pointer semantics. Use `[0]T` only for flexible array member ABI layout. |
 | `T[N]` | `[N]T` | Fixed-size array. Direct match. |
 | `T[N][M]` | `[N][M]T` | Multidimensional array. Direct match. |
 | `struct S { ... }` | `const S = struct { ... }` | Zig structs are namespaced. Use `extern struct` for C ABI compatibility. |
 | `union U { ... }` | `const U = union { ... }` | Use `extern union` for C ABI. For tagged unions, use `union(enum) { ... }`. |
-| `enum E { A, B }` | `const E = enum(c_int) { A, B }` | C enums are `int`-sized. Use `enum(c_int)` for ABI match. |
+| `enum E { A, B }` | `const E = enum(c_int) { A, B }` | C enum compatible integer type is implementation/ABI/enumerator dependent. `enum(c_int)` is acceptable for common ABI interop but NOT a complete C11 sema rule. |
 | `typedef` | `const` alias or `usingnamespace` | Zig prefers `const MyInt = i32;` over `typedef`. |
 | `T (*f)(U, V)` | `*const fn (U, V) T` | Function pointer. Note Zig fn pointers are non-null; use `?*const fn(...)` for nullable. |
 
@@ -106,7 +106,7 @@ Zig has no `alloca`. Use `allocator.alloc` or inline assembly for stack pointer 
 | `while (cond)` | `while (cond)` | Direct match. |
 | `do { ... } while (cond)` | `while (true) { ... if (!cond) break; }` | No direct `do-while` in Zig. |
 | `break` / `continue` | `break` / `continue` | Direct match. |
-| `goto label` | `goto label` | Zig has `goto` for labeled blocks. Use sparingly. |
+| `goto label` | (no equivalent) | Zig has NO arbitrary `goto`. C `goto` must be represented in compiler IR / control-flow graph, NOT mapped to Zig source `goto`. |
 | `setjmp` / `longjmp` | `errdefer` / `try` / `catch` | Zig uses error unions, not setjmp. For C compatibility, implement `setjmp`/`longjmp` as inline assembly saving/restoring the frame pointer and stack pointer. |
 
 ## 4. Functions
@@ -277,9 +277,9 @@ fn abs(x: anytype) @TypeOf(x) {
 
 ### Signed integer overflow
 
-C11 signed integer overflow is undefined behavior. Zig signed integer overflow is defined to wrap in safe modes, but can be caught with `@addWithOverflow`, `@subWithOverflow`, `@mulWithOverflow`.
+C11 signed integer overflow is undefined behavior. Zig signed integer overflow TRAPS in safe modes (Debug, ReleaseSafe). Wrapping requires the `+%` operators or explicit overflow builtins (`@addWithOverflow`, `@subWithOverflow`, `@mulWithOverflow`).
 
-**Implication for `zcc`:** When compiling C11 with `zcc`, the default should match C semantics (UB on signed overflow). In debug builds, `zcc` may optionally emit overflow checks.
+**Implication for `zcc`:** When compiling C11 with `zcc`, the default should match C semantics (UB on signed overflow). In debug builds, `zcc` may optionally emit overflow checks. Do not assume Zig wrapping behavior applies to C code.
 
 ### Pointer arithmetic
 

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -147,10 +147,10 @@ C11 variadic functions are tricky in Zig. For `zcc` implementing C variadics:
 
 | C11 | Zig 0.16 | Notes |
 |---|---|---|
-| `mtx_init` | `std.Thread.Mutex.init` | Zig `Mutex` is a struct, not a pointer. |
+| `mtx_init` | `std.Thread.Mutex{}` | Zig `Mutex` is a struct, not a pointer, and is statically initialized. |
 | `mtx_lock` | `mutex.lock()` | Direct match. |
 | `mtx_unlock` | `mutex.unlock()` | Direct match. |
-| `cnd_init` | `std.Thread.Condition.init` | |
+| `cnd_init` | `std.Thread.Condition{}` | Zig `Condition` is statically initialized. |
 | `cnd_wait` | `condition.wait(&mutex)` | |
 | `cnd_signal` | `condition.signal()` | |
 | `cnd_broadcast` | `condition.broadcast()` | |

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -40,7 +40,7 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 | `struct S { ... }` | `const S = struct { ... }` | Zig structs are namespaced. Use `extern struct` for C ABI compatibility. |
 | `union U { ... }` | `const U = union { ... }` | Use `extern union` for C ABI. For tagged unions, use `union(enum) { ... }`. |
 | `enum E { A, B }` | `const E = enum(c_int) { A, B }` | C enum compatible integer type is implementation/ABI/enumerator dependent. `enum(c_int)` is acceptable for common ABI interop but NOT a complete C11 sema rule. |
-| `typedef` | `const` alias | Zig prefers `const MyInt = i32;` over `typedef`. `usingnamespace` was removed in Zig 0.16; use explicit imports. |
+| `typedef` | `const` alias | Zig prefers `const MyInt = i32;` over `typedef`. |
 | `T (*f)(U, V)` | `*const fn (U, V) T` | Function pointer. Note Zig fn pointers are non-null; use `?*const fn(...)` for nullable. |
 
 ### Type qualifiers and attributes
@@ -52,7 +52,7 @@ This document maps C11 language features to their Zig 0.16 equivalents. It serve
 | `restrict` | `noalias` | Zig `noalias` on pointer parameters. |
 | `_Alignas(N)` | `align(N)` | Zig `align(N)` on types and variables. |
 | `_Alignof(T)` | `@alignOf(T)` | Direct match. |
-| `_Static_assert(E, msg)` | `comptime assert` | Use `comptime { assert(E); }` for compile-time assertions. `@compileLog` does not halt compilation and is not a substitute. |
+| `_Static_assert(E, msg)` | `comptime { assert(E); }` | Use `std.debug.assert` inside `comptime` blocks for compile-time assertions. |
 
 ## 2. Memory and storage
 

--- a/docs/research/c11-zig-mapping.md
+++ b/docs/research/c11-zig-mapping.md
@@ -1,0 +1,340 @@
+# Research — C11 to Zig 0.16 Concept Mapping
+
+This document maps C11 language features to their Zig 0.16 equivalents. It serves two purposes:
+1. Guide the `zcc` implementer on how to represent C11 semantics internally.
+2. Provide a reference for any C-to-Zig translation or interoperability.
+
+## 1. Type system
+
+### Scalar types
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `char` | `i8` or `u8` | C `char` signedness is implementation-defined. `zcc` should match the target ABI (usually `i8` on x86_64, `u8` on arm64). |
+| `short` | `i16` | Always signed in C. |
+| `int` | `i32` | C `int` is at least 16 bits; on all our targets it is 32. |
+| `long` | `i64` (LP64: macOS/Linux x86_64) or `i32` (LLP64: Windows) | Match target ABI. On macOS/Linux x86_64 (LP64), `long` is 64 bits. On Windows (LLP64), `long` is 32 bits. |
+| `long long` | `i64` | Always at least 64 bits. |
+| `unsigned X` | `u8`, `u16`, `u32`, `u64` | Zig has no `unsigned` keyword; use the unsigned variant directly. |
+| `_Bool` | `bool` | Zig `bool` is 1 bit logically, 1 byte physically. C `_Bool` is 1 byte. |
+| `float` | `f32` | IEEE 754 single precision. |
+| `double` | `f64` | IEEE 754 double precision. |
+| `long double` | `f80` or `f128` | Platform-dependent. On x86_64 it is 80-bit extended precision (`f80`). On arm64 it is `f128`. Match the target ABI. |
+| `float _Complex` | `std.math.complex.Complex(f32)` | Zig std lib provides complex numbers. |
+| `double _Complex` | `std.math.complex.Complex(f64)` | |
+| `_Atomic T` | `std.atomic.Value(T)` | For scalar `T`. For structs, use `std.Thread.Mutex` or align to cache line and use atomic builtins. |
+| `void` | `void` | Direct match. |
+| `size_t` | `usize` | Zig `usize` is the pointer-sized unsigned integer. |
+| `ptrdiff_t` | `isize` | Zig `isize` is the pointer-sized signed integer. |
+| `intptr_t` / `uintptr_t` | `isize` / `usize` | Direct match. |
+
+### Derived types
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `T*` | `*T` or `*allowzero T` | Zig `*T` is a non-null, non-optional single-item pointer. For C `NULL`, use `?*T`. For zero-as-valid (e.g. x86 real mode), use `*allowzero T`. |
+| `const T*` | `*const T` | Direct match. |
+| `T[]` (incomplete array) | `[]T` | Zig slice is ptr+len. C incomplete array is just a pointer. |
+| `T[N]` | `[N]T` | Fixed-size array. Direct match. |
+| `T[N][M]` | `[N][M]T` | Multidimensional array. Direct match. |
+| `struct S { ... }` | `const S = struct { ... }` | Zig structs are namespaced. Use `extern struct` for C ABI compatibility. |
+| `union U { ... }` | `const U = union { ... }` | Use `extern union` for C ABI. For tagged unions, use `union(enum) { ... }`. |
+| `enum E { A, B }` | `const E = enum(c_int) { A, B }` | C enums are `int`-sized. Use `enum(c_int)` for ABI match. |
+| `typedef` | `const` alias or `usingnamespace` | Zig prefers `const MyInt = i32;` over `typedef`. |
+| `T (*f)(U, V)` | `*const fn (U, V) T` | Function pointer. Note Zig fn pointers are non-null; use `?*const fn(...)` for nullable. |
+
+### Type qualifiers and attributes
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `const` | `const` | Direct match. |
+| `volatile` | `volatile` | Direct match. |
+| `restrict` | `noalias` | Zig `noalias` on pointer parameters. |
+| `_Alignas(N)` | `align(N)` | Zig `align(N)` on types and variables. |
+| `_Alignof(T)` | `@alignOf(T)` | Direct match. |
+| `_Static_assert(E, msg)` | `@compileLog` or `comptime assert` | Use `comptime { assert(E); }` for compile-time assertions. |
+
+## 2. Memory and storage
+
+### Storage durations
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| Automatic (stack) | Local variable | Direct match. Zig has no implicit stack allocation; locals are on the stack by default. |
+| Static (global / file scope) | `var` at module scope | Direct match. |
+| Thread-local (`_Thread_local`) | `threadlocal` | Zig `threadlocal var` at module scope. |
+| Dynamic (heap) | `allocator.alloc`, `allocator.create` | No implicit heap. Explicit allocator discipline. |
+
+### VLAs (Variable Length Arrays)
+
+C11 VLAs do not map directly to Zig. Zig has no VLA.
+
+```c
+// C11 VLA
+void foo(int n) {
+    int arr[n];  // stack-allocated, size known at runtime
+}
+```
+
+```zig
+// Zig equivalent: allocator or stack slice
+fn foo(n: usize) void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    const arr = try allocator.alloc(i32, n);
+    defer allocator.free(arr);
+}
+```
+
+**Implication for `zcc`:** The compiler must lower C VLAs to either:
+1. `alloca`-style stack allocation (if the backend supports it).
+2. Heap allocation via allocator (safer, but changes semantics for `setjmp`/`longjmp`).
+
+For `zcc` emitting assembly, use the frame pointer + dynamic stack adjustment pattern.
+
+### `alloca`
+
+Zig has no `alloca`. Use `allocator.alloc` or inline assembly for stack pointer manipulation.
+
+## 3. Control flow
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `if (cond)` | `if (cond)` | Direct match. C `if` accepts integers; Zig `if` accepts `bool` only. The compiler must insert `!= 0` for C integer conditions. |
+| `switch (x) { case 1: ... }` | `switch (x) { 1 => ..., else => ... }` | Zig `switch` is exhaustive. C `switch` with `default` maps to `else`. |
+| `for (init; cond; inc)` | `while (cond) : (inc) { ... }` | Zig `while` supports a continue expression. |
+| `while (cond)` | `while (cond)` | Direct match. |
+| `do { ... } while (cond)` | `while (true) { ... if (!cond) break; }` | No direct `do-while` in Zig. |
+| `break` / `continue` | `break` / `continue` | Direct match. |
+| `goto label` | `goto label` | Zig has `goto` for labeled blocks. Use sparingly. |
+| `setjmp` / `longjmp` | `errdefer` / `try` / `catch` | Zig uses error unions, not setjmp. For C compatibility, implement `setjmp`/`longjmp` as inline assembly saving/restoring the frame pointer and stack pointer. |
+
+## 4. Functions
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `T f(U a, V b)` | `fn f(a: U, b: V) T` | Direct match. |
+| `void f(void)` | `fn f() void` | C `f(void)` means no parameters. Zig `fn f() void` is the same. |
+| `T f(...)` | `fn f(args: anytype) T` or comptime varargs | Zig has no C-style varargs in the type system. Use `std.builtin.VaList` for C interop, or comptime tuples for Zig-native varargs. |
+| `inline` | `inline` | Zig `inline fn` forces inlining at the call site. |
+| `_Noreturn` | `noreturn` | Zig `noreturn` is a type, not an attribute. A function returning `noreturn` never returns. |
+| `static` (file scope) | `pub` vs non-`pub` | Zig non-`pub` declarations are module-private. |
+| `extern` | `extern` | Zig `extern` for C ABI compatibility. |
+| `__attribute__((packed))` | `packed struct` | Zig `packed struct` has no padding. |
+| `__attribute__((aligned(N)))` | `align(N)` | Direct match. |
+
+### Variadic functions
+
+C11 variadic functions are tricky in Zig. For `zcc` implementing C variadics:
+
+1. **Internal representation:** Store the parameter list as a slice of `union { int: i64, float: f64, ptr: *anyopaque }` or similar tagged union.
+2. **ABI compliance:** On x86_64 System V, variadic args use the same register/stack convention as fixed args. The callee must know which registers were used for integer vs floating-point args. This is typically handled by the `va_list` type, which in C is a struct tracking register save area and stack args.
+3. **Zig implementation:** Use `std.builtin.VaList` when calling C variadic functions from Zig. When `zcc` emits code for a C variadic function, emit the standard ABI prologue that initializes `va_list` from the register save area.
+
+## 5. Concurrency
+
+### Threads
+
+| C11 (`threads.h`) | Zig 0.16 | Notes |
+|---|---|---|
+| `thrd_create` | `std.Thread.spawn` | Direct match. |
+| `thrd_join` | `thread.join()` | Direct match. |
+| `thrd_exit` | `return` from thread function | Direct match. |
+| `thrd_sleep` | `std.time.sleep` | Nanoseconds in Zig. |
+| `thrd_yield` | `std.Thread.yield` | Direct match. |
+
+### Mutexes and condition variables
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `mtx_init` | `std.Thread.Mutex.init` | Zig `Mutex` is a struct, not a pointer. |
+| `mtx_lock` | `mutex.lock()` | Direct match. |
+| `mtx_unlock` | `mutex.unlock()` | Direct match. |
+| `cnd_init` | `std.Thread.Condition.init` | |
+| `cnd_wait` | `condition.wait(&mutex)` | |
+| `cnd_signal` | `condition.signal()` | |
+| `cnd_broadcast` | `condition.broadcast()` | |
+
+### Atomics
+
+| C11 (`stdatomic.h`) | Zig 0.16 | Notes |
+|---|---|---|
+| `atomic_int` | `std.atomic.Value(i32)` | |
+| `atomic_fetch_add` | `value.fetchAdd(delta, ordering)` | |
+| `atomic_load` | `value.load(ordering)` | |
+| `atomic_store` | `value.store(new, ordering)` | |
+| `atomic_compare_exchange_strong` | `value.cmpxchgStrong(expected, desired, success_order, fail_order)` | |
+| `memory_order_relaxed` | `.monotonic` | Zig uses `.monotonic` for relaxed. |
+| `memory_order_acquire` | `.acquire` | Direct match. |
+| `memory_order_release` | `.release` | Direct match. |
+| `memory_order_seq_cst` | `.seq_cst` | Direct match. |
+
+## 6. Preprocessor and compile-time features
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `#define` | `const`, `comptime var`, `inline fn` | Zig has no textual preprocessor. Use `comptime` for compile-time computation. |
+| `#ifdef` / `#ifndef` | `comptime if` | Zig `comptime if` branches are evaluated at compile time. |
+| `#include` | `@import` | Zig modules are imported by path, not by textual inclusion. |
+| `_Generic` | `switch (@typeInfo(T))` or `comptime if` | Zig's type-based dispatch is done via `comptime` reflection, not `_Generic`. |
+| `static_assert` | `comptime { assert(E); }` | |
+| `__FILE__`, `__LINE__` | `@src()` | Zig `@src()` returns a struct with `file`, `fn_name`, `line`, `column`. |
+| `__func__` | `@src().fn_name` | |
+
+### `_Generic` mapping
+
+C11 `_Generic` selects an expression based on the type of a controlling expression:
+
+```c
+#define abs(x) _Generic((x), \
+    int: abs_int, \
+    long: abs_long, \
+    float: abs_float \
+)(x)
+```
+
+Zig equivalent using `comptime`:
+
+```zig
+fn abs(x: anytype) @TypeOf(x) {
+    const T = @TypeOf(x);
+    return switch (T) {
+        i32 => abs_int(x),
+        i64 => abs_long(x),
+        f32 => abs_float(x),
+        else => @compileError("unsupported type for abs"),
+    };
+}
+```
+
+**Implication for `zcc`:** The preprocessor must expand `_Generic` to the selected expression. The compiler's AST should represent `_Generic` as a type-switch node, lowered to a direct call in sema.
+
+## 7. Standard library mapping
+
+### stdio.h
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `FILE*` | `std.fs.File` | Zig file handles are structs, not opaque pointers. |
+| `fopen` | `std.fs.cwd().openFile` | |
+| `fread` / `fwrite` | `file.read` / `file.write` | |
+| `fseek` / `ftell` | `file.seekTo` / `file.getPos` | |
+| `printf` | `std.debug.print` or `std.io.Writer.print` | Zig `print` is type-safe; use `{}` for any type. |
+| `sprintf` | `std.fmt.bufPrint` | |
+| `malloc` / `free` | `allocator.alloc` / `allocator.free` | Explicit allocator discipline. |
+| `exit` | `std.process.exit` | |
+| `abort` | `std.process.abort` | |
+
+### string.h
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `memcpy` | `@memcpy` | Zig `@memcpy` is a builtin, not a libc call. |
+| `memmove` | `@memmove` | |
+| `memset` | `@memset` | |
+| `memcmp` | `std.mem.eql` or `std.mem.compare` | |
+| `strlen` | `std.mem.len` or `std.mem.sliceTo` | |
+| `strcpy` / `strncpy` | `std.mem.copy` | Zig copies are always bounded. |
+| `strcat` / `strncat` | `std.mem.concat` | |
+
+### stdlib.h
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `qsort` | `std.sort.block` or `std.sort.pdq` | Zig sort is type-safe and generic. |
+| `bsearch` | `std.sort.binarySearch` | |
+| `abs` / `labs` / `llabs` | `@abs` | Zig builtin. |
+| `div` / `ldiv` | `@divTrunc`, `@divFloor`, `@divExact` | Zig has multiple division modes. |
+| `rand` | `std.crypto.random` or `std.Random` | Zig prefers cryptographically secure randomness. |
+
+### math.h
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `sin`, `cos`, `tan` | `std.math.sin`, `std.math.cos`, `std.math.tan` | |
+| `sqrt` | `std.math.sqrt` | |
+| `pow` | `std.math.pow` | |
+| `floor` / `ceil` / `round` | `std.math.floor`, `std.math.ceil`, `std.math.round` | |
+| `INFINITY` | `std.math.inf` | |
+| `NAN` | `std.math.nan` | |
+| `isnan` | `std.math.isNan` | |
+| `isinf` | `std.math.isInf` | |
+
+## 8. ABI and calling conventions
+
+| C11 | Zig 0.16 | Notes |
+|---|---|---|
+| `__attribute__((cdecl))` | `.C` calling convention | Zig `callconv(.C)` for C ABI. |
+| `__attribute__((stdcall))` | `.Stdcall` | Windows only. |
+| `__attribute__((fastcall))` | `.Fastcall` | |
+| `__attribute__((thiscall))` | `.Thiscall` | C++ only, but relevant for C++ interop. |
+| `__attribute__((sysv_abi))` | `.C` on x86_64 Linux/macOS | System V AMD64 ABI is the default `.C` on those platforms. |
+| `__attribute__((ms_abi))` | `.C` on x86_64 Windows | Microsoft x64 ABI is the default `.C` on Windows. |
+| `__attribute__((vector_size(N)))` | `@Vector(N, T)` | Zig SIMD vectors. |
+| `__attribute__((noreturn))` | `noreturn` return type | |
+
+## 9. Edge cases and warnings
+
+### Signed integer overflow
+
+C11 signed integer overflow is undefined behavior. Zig signed integer overflow is defined to wrap in safe modes, but can be caught with `@addWithOverflow`, `@subWithOverflow`, `@mulWithOverflow`.
+
+**Implication for `zcc`:** When compiling C11 with `zcc`, the default should match C semantics (UB on signed overflow). In debug builds, `zcc` may optionally emit overflow checks.
+
+### Pointer arithmetic
+
+C11 pointer arithmetic is only defined within arrays (or one past the end). Zig pointer arithmetic is more restrictive: `ptr + n` requires `ptr` to be a multi-item pointer `[*]T`, not a single-item pointer `*T`.
+
+**Implication for `zcc`:** The compiler's internal representation should use `[*]T` for all C pointers that may participate in arithmetic.
+
+### Integer promotion and usual arithmetic conversions
+
+C11 has complex rules for integer promotion (`char` → `int`, etc.) and usual arithmetic conversions (balancing `int` and `unsigned int`). Zig has no implicit integer promotion: `u8 + u8` produces `u8`, not `u16` or `u32`.
+
+**Implication for `zcc`:** The sema phase must explicitly insert cast nodes for all C implicit promotions. The IR should represent these casts explicitly.
+
+### `union` punning
+
+C11 allows reading a `union` member other than the one last written (type punning). Zig `union` (non-`extern`, non-`packed`) has active field safety checks. Use `extern union` or `packed union` for C-compatible punning.
+
+**Implication for `zcc`:** All C `union` types should map to `extern union` in any Zig interop layer. The compiler's internal representation should not enforce active field tracking.
+
+### Flexible array members
+
+C99/C11 flexible array member:
+
+```c
+struct Buffer {
+    size_t len;
+    char data[];  // flexible array member
+};
+```
+
+Zig has no direct equivalent. Use a slice:
+
+```zig
+const Buffer = extern struct {
+    len: usize,
+    data: [0]u8,  // zero-length array, then access via pointer arithmetic
+};
+```
+
+Or represent as:
+
+```zig
+const Buffer = struct {
+    len: usize,
+    data: []u8,  // ptr+len slice
+};
+```
+
+**Implication for `zcc`:** For ABI compatibility, use `[0]T` at the end of an `extern struct`. For internal representation, use a slice.
+
+## 10. References
+
+- C11 Standard (N1570): https://open-std.org/jtc1/sc22/WG14/www/docs/n1570.pdf
+- Zig 0.16 Language Reference: https://ziglang.org/documentation/0.16.0/
+- Zig `std.atomic.Value`: https://github.com/ziglang/zig/blob/master/lib/std/atomic/Value.zig
+- Zig `std.Thread`: https://github.com/ziglang/zig/blob/master/lib/std/Thread.zig
+- System V AMD64 ABI: https://gitlab.com/x86-psABIs/x86-64-ABI
+- arocc (C compiler in Zig): https://github.com/Vexu/arocc

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -42,7 +42,7 @@ fn readSourceFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
 | Backend | What it does | When to use |
 |---|---|---|
 | `std.Io.Threaded` | Thread pool with work stealing | Default for CPU-bound compiler work. |
-| `std.Io.Evented` | io_uring (Linux), kqueue (macOS), GCD (macOS) | Experimental. Use for I/O-bound phases (reading many TUs, writing object files). |
+| `std.Io.Evented` | io_uring (Linux), GCD (macOS) | Experimental. Use for I/O-bound phases (reading many TUs, writing object files). |
 
 **Implication for `zcc`:** Pass `std.Io` through the driver. Do not design around old `async`/`await` keywords. The driver should create one `std.Io.Threaded` instance at startup and pass it to every compilation phase that can benefit from parallelism.
 
@@ -211,7 +211,7 @@ fn runWithPipes(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) !C
 }
 ```
 
-**Implication for `zcc`:** Use `std.process.run` for simple fire-and-forget invocations (assembler, linker). Use the lower-level `std.process.spawn` API when you need to capture stdout/stderr or stream data to the child.
+**Implication for `zcc`:** Use `std.process.run` for simple synchronous invocations (assembler, linker) — it blocks until the child exits. Use the lower-level `std.process.spawn` API when you need non-blocking execution, capture stdout/stderr, or stream data to the child.
 
 ## 7. Combining patterns: a full driver sketch
 

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -21,13 +21,19 @@ Zig 0.16 removed the `async` and `await` keywords. Asynchrony is now expressed t
 fn lexFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !TokenList {
     // given a source file path
     // when we read it asynchronously
-    var future = io.async(std.fs.readFile, .{ allocator, path });
+    var future = io.async(readSourceFile, .{ allocator, path });
     defer future.cancel(io) catch {};
     const source = try future.await(io);
     defer allocator.free(source);
 
     // then we tokenize the contents
     return try tokenize(allocator, source);
+}
+
+fn readSourceFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    return try file.readToEndAlloc(allocator, 1024 * 1024 * 10);
 }
 ```
 
@@ -40,27 +46,25 @@ fn lexFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !TokenLis
 
 **Implication for `zcc`:** Pass `std.Io` through the driver. Do not design around old `async`/`await` keywords. The driver should create one `std.Io.Threaded` instance at startup and pass it to every compilation phase that can benefit from parallelism.
 
-## 2. Thread pools (`std.Thread.Pool`)
+## 2. Thread pools (`std.Io.Threaded`)
 
-`std.Thread.Pool` is the workhorse for CPU-bound parallelism. In 0.16 it supports `spawnWg` for automatic WaitGroup tracking.
+`std.Io.Threaded` is the CPU-bound parallelism backend in Zig 0.16. It provides a thread pool with work stealing, accessed through the `std.Io` interface.
 
 ### Pattern: parallel compilation units
 
 ```zig
 fn compileAll(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
     // given a list of translation units
-    var pool: std.Thread.Pool = undefined;
-    try pool.init(.{ .allocator = gpa, .n_jobs = 4 });
-    defer pool.deinit();
-
-    // when we spawn one task per TU
-    var wg: std.Thread.WaitGroup = .{};
+    // when we create a group and spawn one concurrent task per TU
+    var group = std.Io.Group.init(gpa);
+    defer group.deinit();
     for (tus) |tu| {
-        pool.spawnWg(&wg, compileTu, .{ gpa, io, tu });
+        const future = try io.concurrent(compileTu, .{ gpa, io, tu });
+        group.add(future);
     }
 
     // then we wait for all tasks to complete
-    wg.wait();
+    try group.awaitAll(io);
 }
 ```
 
@@ -68,39 +72,44 @@ fn compileAll(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) 
 
 | Method | Behavior |
 |---|---|
-| `spawnWg(&wg, func, args)` | Spawn task, auto-increment WaitGroup, auto-decrement on completion. |
-| `waitAndWork(&wg)` | Caller thread steals tasks from the pool while waiting. |
-| `spawn(func, args)` | Fire-and-forget. No WaitGroup tracking. |
+| `io.concurrent(func, args)` | Require concurrency; returns `!std.Io.Future(T)`. Fails if backend cannot oversubscribe. |
+| `group.add(future)` | Add a future to the group for batch awaiting. |
+| `group.awaitAll(io)` | Block until every future in the group resolves. |
+| `io.async(func, args)` | Decouple call from return; may or may not run concurrently. |
 
-**Implication for `zcc`:** Use `spawnWg` for per-TU compilation. Each TU gets its own `ArenaAllocator`. The main thread calls `wg.wait()` and then proceeds to the link step.
+**Implication for `zcc`:** Use `io.concurrent` for per-TU compilation. Each TU gets its own `ArenaAllocator`. The main thread calls `group.awaitAll(io)` and then proceeds to the link step.
 
-## 3. WaitGroups (`std.Thread.WaitGroup`)
+## 3. Groups (`std.Io.Group`)
 
-WaitGroups synchronize groups of tasks. In 0.16 they are built on `std.atomic.Value(usize)`.
+`std.Io.Group` synchronizes batches of futures. It replaces the old `std.Thread.WaitGroup` pattern in 0.16.
 
 ### Pattern: phased pipeline
 
 ```zig
 fn pipeline(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
     // given translation units
-    var lex_wg: std.Thread.WaitGroup = .{};
-    var parse_wg: std.Thread.WaitGroup = .{};
+    var lex_group = std.Io.Group.init(gpa);
+    defer lex_group.deinit();
+    var parse_group = std.Io.Group.init(gpa);
+    defer parse_group.deinit();
 
     // when we lex all TUs in parallel
     for (tus) |tu| {
-        io.concurrent(lexTu, .{ gpa, tu, &lex_wg });
+        const future = try io.concurrent(lexTu, .{ gpa, tu });
+        lex_group.add(future);
     }
-    lex_wg.wait();
+    try lex_group.awaitAll(io);
 
     // then we parse all TUs in parallel
     for (tus) |tu| {
-        io.concurrent(parseTu, .{ gpa, tu, &parse_wg });
+        const future = try io.concurrent(parseTu, .{ gpa, tu });
+        parse_group.add(future);
     }
-    parse_wg.wait();
+    try parse_group.awaitAll(io);
 }
 ```
 
-**Implication for `zcc`:** If you want a phased pipeline (all lexing done before any parsing starts), use separate WaitGroups per phase. If you want a streaming pipeline (parse starts as soon as lexing finishes for one TU), use a channel or a mutex-protected queue.
+**Implication for `zcc`:** If you want a phased pipeline (all lexing done before any parsing starts), use separate `Io.Group` instances per phase. If you want a streaming pipeline (parse starts as soon as lexing finishes for one TU), use a mutex-protected queue or `std.DoublyLinkedList` + `Mutex`.
 
 ## 4. Lock-free primitives (`std.atomic.Value`)
 
@@ -137,7 +146,7 @@ fn enterSymbol(symtab: *SymbolTable, sym: Symbol) void {
 - Unique ID generation (seq_cst to avoid collisions).
 - Global symbol table versioning (seq_cst).
 
-Do not use it for complex data structures. For MPMC queues, use `std.DoublyLinkedList` + `Mutex`, or third-party `HTRMC/zig-concurrent-queue` (block-based, zero-lock).
+Do not use it for complex data structures. For MPMC queues, use `std.DoublyLinkedList` + `Mutex`. (Zero-external-deps mandate: do not add third-party queue libraries.)
 
 ## 5. Memory arenas (`std.heap.ArenaAllocator`)
 
@@ -167,22 +176,24 @@ fn compileTu(gpa: std.mem.Allocator, io: std.Io, tu: TranslationUnit) !ObjectFil
 
 ## 6. Multi-process workers (`std.process.Child`)
 
-For sandboxing or invoking external tools (assembler, linker), use `std.process.Child`.
+For sandboxing or invoking external tools (assembler, linker), use `std.process`.
 
 ### Pattern: invoke system assembler
 
 ```zig
-fn assemble(gpa: std.mem.Allocator, asm_path: []const u8, obj_path: []const u8) !void {
+fn assemble(gpa: std.mem.Allocator, io: std.Io, asm_path: []const u8, obj_path: []const u8) !void {
     // given an assembly text file
-    const result = try std.process.Child.run(.{
-        .allocator = gpa,
+    const result = try std.process.run(gpa, io, .{
         .argv = &.{ "as", "-o", obj_path, asm_path },
     });
 
     // then we check the exit code
-    if (result.term.Exited != 0) {
-        std.log.err("assembler failed: {s}", .{result.stderr});
-        return error.AssembleFailed;
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            std.log.err("assembler failed: {s}", .{result.stderr});
+            return error.AssembleFailed;
+        },
+        else => return error.AssembleFailed,
     }
 }
 ```
@@ -190,23 +201,24 @@ fn assemble(gpa: std.mem.Allocator, asm_path: []const u8, obj_path: []const u8) 
 ### Pattern: lower-level pipe control
 
 ```zig
-fn runWithPipes(gpa: std.mem.Allocator, argv: []const []const u8) !ChildOutput {
-    var child = std.process.Child.init(argv, gpa);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-    try child.spawn();
+fn runWithPipes(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) !ChildOutput {
+    var child = try std.process.spawn(io, .{
+        .argv = argv,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
 
-    const stdout = try child.stdout.?.readToEndAlloc(gpa, 1024 * 1024);
+    const stdout = try child.stdout.reader().readAllAlloc(gpa, 1024 * 1024);
     errdefer gpa.free(stdout);
-    const stderr = try child.stderr.?.readToEndAlloc(gpa, 1024 * 1024);
+    const stderr = try child.stderr.reader().readAllAlloc(gpa, 1024 * 1024);
     errdefer gpa.free(stderr);
 
-    const term = try child.wait();
+    const term = try child.wait(io);
     return .{ .term = term, .stdout = stdout, .stderr = stderr };
 }
 ```
 
-**Implication for `zcc`:** Use `std.process.Child.run` for simple fire-and-forget invocations (assembler, linker). Use the lower-level API when you need to capture stdout/stderr or stream data to the child.
+**Implication for `zcc`:** Use `std.process.run` for simple fire-and-forget invocations (assembler, linker). Use the lower-level `std.process.spawn` API when you need to capture stdout/stderr or stream data to the child.
 
 ## 7. Combining patterns: a full driver sketch
 
@@ -220,23 +232,22 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    // when we initialize the I/O backend and thread pool
-    var io = std.Io.Threaded.init(.{ .allocator = allocator, .n_jobs = 4 });
-    defer io.deinit();
-
-    var pool: std.Thread.Pool = undefined;
-    try pool.init(.{ .allocator = allocator, .n_jobs = 4 });
-    defer pool.deinit();
+    // when we initialize the I/O backend
+    var threaded = try std.Io.Threaded.init(allocator, .{ .n_jobs = 4 });
+    defer threaded.deinit();
+    const io = threaded.io();
 
     // compile each TU in parallel
-    var wg: std.Thread.WaitGroup = .{};
+    var group = std.Io.Group.init(allocator);
+    defer group.deinit();
     for (args[1..]) |tu_path| {
-        pool.spawnWg(&wg, compileTuPipeline, .{ allocator, io, tu_path });
+        const future = try io.concurrent(compileTuPipeline, .{ allocator, io, tu_path });
+        group.add(future);
     }
-    wg.wait();
+    try group.awaitAll(io);
 
     // then link all object files
-    try linkObjects(allocator, &obj_files);
+    try linkObjects(allocator, io, &obj_files);
 }
 ```
 
@@ -245,7 +256,7 @@ pub fn main() !void {
 | Removed / Deprecated | Replacement | Why |
 |---|---|---|
 | `std.atomic.Atomic` | `std.atomic.Value` | Cleaner API, same builtins underneath. |
-| `std.atomic.Queue` / `std.atomic.Stack` | `std.DoublyLinkedList` + `Mutex`, or `zig-concurrent-queue` | Removed from std lib. |
+| `std.atomic.Queue` / `std.atomic.Stack` | `std.DoublyLinkedList` + `Mutex` | Removed from std lib. Do not add third-party replacements. |
 | `heap.ThreadSafeAllocator` | `heap.ArenaAllocator` (now thread-safe) | Simplified API. |
 | `@cImport` | `addTranslateC` in build system | C translation moved to build time. |
 | `@Type` | `@Int`, `@Struct`, `@Union`, `@Enum`, `@Pointer`, `@Fn`, `@Tuple`, `@EnumLiteral` | Finer-grained builtins. |
@@ -254,8 +265,7 @@ pub fn main() !void {
 
 - Zig 0.16.0 Release Notes: https://ziglang.org/download/0.16.0/release-notes.html
 - Zig Language Reference: https://ziglang.org/documentation/0.16.0/
-- `std.Thread.Pool`: https://github.com/ziglang/zig/blob/master/lib/std/Thread/Pool.zig
-- `std.process.Child`: https://github.com/ziglang/zig/blob/master/lib/std/process/Child.zig
+- `std.Io.Threaded`: https://github.com/ziglang/zig/blob/master/lib/std/Io/Threaded.zig
+- `std.process`: https://github.com/ziglang/zig/blob/master/lib/std/process.zig
 - `std.MultiArrayList`: https://github.com/ziglang/zig/blob/master/lib/std/multi_array_list.zig
 - Zig's New Async I/O (Andrew Kelley): https://andrewkelley.me/post/zig-new-async-io-text-version.html
-- `zig-concurrent-queue`: https://github.com/HTRMC/zig-concurrent-queue

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -193,33 +193,7 @@ fn assemble(gpa: std.mem.Allocator, io: std.Io, asm_path: []const u8, obj_path: 
 }
 ```
 
-### Pattern: lower-level pipe control
-
-```zig
-fn runWithPipes(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) !ChildOutput {
-    var child = try std.process.spawn(io, .{
-        .argv = argv,
-        .stdout = .pipe,
-        .stderr = .pipe,
-    });
-    defer child.kill(io) catch {};
-
-    var stdout_buf: [1024 * 1024]u8 = undefined;
-    const stdout_len = try child.stdout.reader().readAll(&stdout_buf);
-    const stdout = try gpa.dupe(u8, stdout_buf[0..stdout_len]);
-    errdefer gpa.free(stdout);
-
-    var stderr_buf: [1024 * 1024]u8 = undefined;
-    const stderr_len = try child.stderr.reader().readAll(&stderr_buf);
-    const stderr = try gpa.dupe(u8, stderr_buf[0..stderr_len]);
-    errdefer gpa.free(stderr);
-
-    const term = try child.wait(io);
-    return .{ .term = term, .stdout = stdout, .stderr = stderr };
-}
-```
-
-**Implication for `zcc`:** Use `std.process.run` for simple synchronous invocations (assembler, linker) — it blocks until the child exits. Use the lower-level `std.process.spawn` API when you need non-blocking execution, capture stdout/stderr, or stream data to the child.
+**Implication for `zcc`:** Use `std.process.run` for simple synchronous invocations (assembler, linker) — it blocks until the child exits. For non-blocking execution or streaming stdout/stderr, use `std.process.spawn` with `.stdout = .pipe` / `.stderr = .pipe`, then read via `std.Io.File.reader(io, &buffer)` and `Reader.allocRemaining`. Consult the Zig 0.16 stdlib (`std.Io.File.zig`, `std.process.zig`) for exact signatures — the pipe-reader API is detailed and out of scope for this guide.
 
 ## 7. Combining patterns: a full driver sketch
 

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -13,7 +13,7 @@ Zig 0.16 removed the `async` and `await` keywords. Asynchrony is now expressed t
 | `io.async(func, args)` | `Future(T)` | You want to decouple the call from the return. The backend may or may not run it concurrently. |
 | `io.concurrent(func, args)` | `Future(T)` | You require concurrency. Fails with `error.ConcurrencyUnavailable` if the backend cannot oversubscribe. |
 | `future.await(io)` | `T` or `!T` | Block until the future resolves. Idempotent. |
-| `future.cancel(io)` | `void` or `!void` | Cancel the future. Idempotent. |
+| `future.cancel(io)` | `Result` (same type as `await`) | Cancel the future. Returns the same result type the future would have produced from `await`; callers must handle it. Idempotent. |
 
 ### Example: async file read during lexing
 
@@ -179,6 +179,8 @@ fn assemble(gpa: std.mem.Allocator, io: std.Io, asm_path: []const u8, obj_path: 
     const result = try std.process.run(gpa, io, .{
         .argv = &.{ "as", "-o", obj_path, asm_path },
     });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
 
     // then we check the exit code
     switch (result.term) {
@@ -200,10 +202,16 @@ fn runWithPipes(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) !C
         .stdout = .pipe,
         .stderr = .pipe,
     });
+    defer child.kill(io) catch {};
 
-    const stdout = try child.stdout.reader().readAllAlloc(gpa, 1024 * 1024);
+    var stdout_buf: [1024 * 1024]u8 = undefined;
+    const stdout_len = try child.stdout.reader().readAll(&stdout_buf);
+    const stdout = try gpa.dupe(u8, stdout_buf[0..stdout_len]);
     errdefer gpa.free(stdout);
-    const stderr = try child.stderr.reader().readAllAlloc(gpa, 1024 * 1024);
+
+    var stderr_buf: [1024 * 1024]u8 = undefined;
+    const stderr_len = try child.stderr.reader().readAll(&stderr_buf);
+    const stderr = try gpa.dupe(u8, stderr_buf[0..stderr_len]);
     errdefer gpa.free(stderr);
 
     const term = try child.wait(io);

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -193,7 +193,7 @@ fn assemble(gpa: std.mem.Allocator, io: std.Io, asm_path: []const u8, obj_path: 
 }
 ```
 
-**Implication for `zcc`:** Use `std.process.run` for simple synchronous invocations (assembler, linker) — it blocks until the child exits. For non-blocking execution or streaming stdout/stderr, use `std.process.spawn` with `.stdout = .pipe` / `.stderr = .pipe`, then read via `std.Io.File.reader(io, &buffer)` and `Reader.allocRemaining`. Consult the Zig 0.16 stdlib (`std.Io.File.zig`, `std.process.zig`) for exact signatures — the pipe-reader API is detailed and out of scope for this guide.
+**Implication for `zcc`:** Use `std.process.run` for simple synchronous invocations (assembler, linker) — it blocks until the child exits. For pipe output, use `std.process.spawn` with `.stdout = .pipe` / `.stderr = .pipe`, then read from the returned `File` with `file.reader(io, buffer)` and, if you want to slurp the entire stream, `reader.allocRemaining(gpa, .unlimited)`. Consult the Zig 0.16 stdlib (`std.Io.File.zig`, `std.process.zig`) for exact signatures — the pipe-reader API is detailed and out of scope for this guide.
 
 ## 7. Combining patterns: a full driver sketch
 

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -224,7 +224,7 @@ fn runWithPipes(gpa: std.mem.Allocator, io: std.Io, argv: []const []const u8) !C
 
 ```zig
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -233,7 +233,7 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     // when we initialize the I/O backend
-    var threaded = try std.Io.Threaded.init(allocator, .{ .n_jobs = 4 });
+    var threaded = try std.Io.Threaded.init(allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
 

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -1,0 +1,261 @@
+# Research — Zig 0.16 Async Patterns for Compiler Workloads
+
+This document maps Zig 0.16 concurrency primitives to the specific needs of a C11 compiler. It is a living reference: update it when new Zig versions land or when `zcc` adopts a pattern not listed here.
+
+## 1. The `std.Io` interface (replaces old `async`/`await`)
+
+Zig 0.16 removed the `async` and `await` keywords. Asynchrony is now expressed through the `std.Io` interface, passed like `Allocator`.
+
+### Core primitives
+
+| Primitive | Returns | Use when |
+|---|---|---|
+| `io.async(func, args)` | `Future(T)` | You want to decouple the call from the return. The backend may or may not run it concurrently. |
+| `io.concurrent(func, args)` | `Future(T)` | You require concurrency. Fails with `error.ConcurrencyUnavailable` if the backend cannot oversubscribe. |
+| `future.await(io)` | `T` or `!T` | Block until the future resolves. Idempotent. |
+| `future.cancel(io)` | `void` or `!void` | Cancel the future. Idempotent. |
+
+### Example: async file read during lexing
+
+```zig
+fn lexFile(io: std.Io, allocator: std.mem.Allocator, path: []const u8) !TokenList {
+    // given a source file path
+    // when we read it asynchronously
+    var future = io.async(std.fs.readFile, .{ allocator, path });
+    defer future.cancel(io) catch {};
+    const source = try future.await(io);
+    defer allocator.free(source);
+
+    // then we tokenize the contents
+    return try tokenize(allocator, source);
+}
+```
+
+### Backends
+
+| Backend | What it does | When to use |
+|---|---|---|
+| `std.Io.Threaded` | Thread pool with work stealing | Default for CPU-bound compiler work. |
+| `std.Io.Evented` | io_uring (Linux), kqueue (macOS), GCD (macOS) | Experimental. Use for I/O-bound phases (reading many TUs, writing object files). |
+
+**Implication for `zcc`:** Pass `std.Io` through the driver. Do not design around old `async`/`await` keywords. The driver should create one `std.Io.Threaded` instance at startup and pass it to every compilation phase that can benefit from parallelism.
+
+## 2. Thread pools (`std.Thread.Pool`)
+
+`std.Thread.Pool` is the workhorse for CPU-bound parallelism. In 0.16 it supports `spawnWg` for automatic WaitGroup tracking.
+
+### Pattern: parallel compilation units
+
+```zig
+fn compileAll(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
+    // given a list of translation units
+    var pool: std.Thread.Pool = undefined;
+    try pool.init(.{ .allocator = gpa, .n_jobs = 4 });
+    defer pool.deinit();
+
+    // when we spawn one task per TU
+    var wg: std.Thread.WaitGroup = .{};
+    for (tus) |tu| {
+        pool.spawnWg(&wg, compileTu, .{ gpa, io, tu });
+    }
+
+    // then we wait for all tasks to complete
+    wg.wait();
+}
+```
+
+### Key methods
+
+| Method | Behavior |
+|---|---|
+| `spawnWg(&wg, func, args)` | Spawn task, auto-increment WaitGroup, auto-decrement on completion. |
+| `waitAndWork(&wg)` | Caller thread steals tasks from the pool while waiting. |
+| `spawn(func, args)` | Fire-and-forget. No WaitGroup tracking. |
+
+**Implication for `zcc`:** Use `spawnWg` for per-TU compilation. Each TU gets its own `ArenaAllocator`. The main thread calls `wg.wait()` and then proceeds to the link step.
+
+## 3. WaitGroups (`std.Thread.WaitGroup`)
+
+WaitGroups synchronize groups of tasks. In 0.16 they are built on `std.atomic.Value(usize)`.
+
+### Pattern: phased pipeline
+
+```zig
+fn pipeline(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
+    // given translation units
+    var lex_wg: std.Thread.WaitGroup = .{};
+    var parse_wg: std.Thread.WaitGroup = .{};
+
+    // when we lex all TUs in parallel
+    for (tus) |tu| {
+        io.concurrent(lexTu, .{ gpa, tu, &lex_wg });
+    }
+    lex_wg.wait();
+
+    // then we parse all TUs in parallel
+    for (tus) |tu| {
+        io.concurrent(parseTu, .{ gpa, tu, &parse_wg });
+    }
+    parse_wg.wait();
+}
+```
+
+**Implication for `zcc`:** If you want a phased pipeline (all lexing done before any parsing starts), use separate WaitGroups per phase. If you want a streaming pipeline (parse starts as soon as lexing finishes for one TU), use a channel or a mutex-protected queue.
+
+## 4. Lock-free primitives (`std.atomic.Value`)
+
+`std.atomic.Value(T)` replaced `std.atomic.Atomic` in 0.16. It is a thin wrapper over atomic builtins.
+
+### Pattern: diagnostic counter
+
+```zig
+var error_count = std.atomic.Value(usize).init(0);
+
+fn reportError() void {
+    _ = error_count.fetchAdd(1, .monotonic);
+}
+
+fn hasErrors() bool {
+    return error_count.load(.acquire) > 0;
+}
+```
+
+### Pattern: global symbol table versioning
+
+```zig
+var symtab_version = std.atomic.Value(u32).init(0);
+
+fn enterSymbol(symtab: *SymbolTable, sym: Symbol) void {
+    const version = symtab_version.fetchAdd(1, .seq_cst);
+    sym.version = version;
+    // ... insert into symtab with mutex or lock-free structure
+}
+```
+
+**Implication for `zcc`:** Use `std.atomic.Value` for:
+- Error/warning counters (monotonic is sufficient).
+- Unique ID generation (seq_cst to avoid collisions).
+- Global symbol table versioning (seq_cst).
+
+Do not use it for complex data structures. For MPMC queues, use `std.DoublyLinkedList` + `Mutex`, or third-party `HTRMC/zig-concurrent-queue` (block-based, zero-lock).
+
+## 5. Memory arenas (`std.heap.ArenaAllocator`)
+
+In 0.16, `heap.ArenaAllocator` is thread-safe and lock-free. This is ideal for per-TU allocation.
+
+### Pattern: one arena per TU
+
+```zig
+fn compileTu(gpa: std.mem.Allocator, io: std.Io, tu: TranslationUnit) !ObjectFile {
+    // given a translation unit
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // when we allocate all AST/IR data in the arena
+    const tokens = try lex(a, tu.source);
+    const ast = try parse(a, tokens);
+    const ir = try lower(a, ast);
+    const obj = try codegen(a, ir);
+
+    // then we return the object file; the arena frees everything on defer
+    return obj;
+}
+```
+
+**Implication for `zcc`:** Every TU gets its own `ArenaAllocator`. All AST nodes, IR instructions, and local symbol tables live in the arena. The object file (or assembly text) is the only thing that escapes the arena. Deinit the arena after the TU is fully compiled.
+
+## 6. Multi-process workers (`std.process.Child`)
+
+For sandboxing or invoking external tools (assembler, linker), use `std.process.Child`.
+
+### Pattern: invoke system assembler
+
+```zig
+fn assemble(gpa: std.mem.Allocator, asm_path: []const u8, obj_path: []const u8) !void {
+    // given an assembly text file
+    const result = try std.process.Child.run(.{
+        .allocator = gpa,
+        .argv = &.{ "as", "-o", obj_path, asm_path },
+    });
+
+    // then we check the exit code
+    if (result.term.Exited != 0) {
+        std.log.err("assembler failed: {s}", .{result.stderr});
+        return error.AssembleFailed;
+    }
+}
+```
+
+### Pattern: lower-level pipe control
+
+```zig
+fn runWithPipes(gpa: std.mem.Allocator, argv: []const []const u8) !ChildOutput {
+    var child = std.process.Child.init(argv, gpa);
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+
+    const stdout = try child.stdout.?.readToEndAlloc(gpa, 1024 * 1024);
+    errdefer gpa.free(stdout);
+    const stderr = try child.stderr.?.readToEndAlloc(gpa, 1024 * 1024);
+    errdefer gpa.free(stderr);
+
+    const term = try child.wait();
+    return .{ .term = term, .stdout = stdout, .stderr = stderr };
+}
+```
+
+**Implication for `zcc`:** Use `std.process.Child.run` for simple fire-and-forget invocations (assembler, linker). Use the lower-level API when you need to capture stdout/stderr or stream data to the child.
+
+## 7. Combining patterns: a full driver sketch
+
+```zig
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // given CLI arguments
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    // when we initialize the I/O backend and thread pool
+    var io = std.Io.Threaded.init(.{ .allocator = allocator, .n_jobs = 4 });
+    defer io.deinit();
+
+    var pool: std.Thread.Pool = undefined;
+    try pool.init(.{ .allocator = allocator, .n_jobs = 4 });
+    defer pool.deinit();
+
+    // compile each TU in parallel
+    var wg: std.Thread.WaitGroup = .{};
+    for (args[1..]) |tu_path| {
+        pool.spawnWg(&wg, compileTuPipeline, .{ allocator, io, tu_path });
+    }
+    wg.wait();
+
+    // then link all object files
+    try linkObjects(allocator, &obj_files);
+}
+```
+
+## 8. What not to use
+
+| Removed / Deprecated | Replacement | Why |
+|---|---|---|
+| `std.atomic.Atomic` | `std.atomic.Value` | Cleaner API, same builtins underneath. |
+| `std.atomic.Queue` / `std.atomic.Stack` | `std.DoublyLinkedList` + `Mutex`, or `zig-concurrent-queue` | Removed from std lib. |
+| `heap.ThreadSafeAllocator` | `heap.ArenaAllocator` (now thread-safe) | Simplified API. |
+| `@cImport` | `addTranslateC` in build system | C translation moved to build time. |
+| `@Type` | `@Int`, `@Struct`, `@Union`, `@Enum`, `@Pointer`, `@Fn`, `@Tuple`, `@EnumLiteral` | Finer-grained builtins. |
+
+## 9. References
+
+- Zig 0.16.0 Release Notes: https://ziglang.org/download/0.16.0/release-notes.html
+- Zig Language Reference: https://ziglang.org/documentation/0.16.0/
+- `std.Thread.Pool`: https://github.com/ziglang/zig/blob/master/lib/std/Thread/Pool.zig
+- `std.process.Child`: https://github.com/ziglang/zig/blob/master/lib/std/process/Child.zig
+- `std.MultiArrayList`: https://github.com/ziglang/zig/blob/master/lib/std/multi_array_list.zig
+- Zig's New Async I/O (Andrew Kelley): https://andrewkelley.me/post/zig-new-async-io-text-version.html
+- `zig-concurrent-queue`: https://github.com/HTRMC/zig-concurrent-queue

--- a/docs/research/zig-async-patterns.md
+++ b/docs/research/zig-async-patterns.md
@@ -56,15 +56,13 @@ fn readSourceFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
 fn compileAll(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
     // given a list of translation units
     // when we create a group and spawn one concurrent task per TU
-    var group = std.Io.Group.init(gpa);
-    defer group.deinit();
+    var group: std.Io.Group = .init;
     for (tus) |tu| {
-        const future = try io.concurrent(compileTu, .{ gpa, io, tu });
-        group.add(future);
+        try group.concurrent(io, compileTu, .{ gpa, io, tu });
     }
 
     // then we wait for all tasks to complete
-    try group.awaitAll(io);
+    try group.await(io);
 }
 ```
 
@@ -72,40 +70,35 @@ fn compileAll(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) 
 
 | Method | Behavior |
 |---|---|
-| `io.concurrent(func, args)` | Require concurrency; returns `!std.Io.Future(T)`. Fails if backend cannot oversubscribe. |
-| `group.add(future)` | Add a future to the group for batch awaiting. |
-| `group.awaitAll(io)` | Block until every future in the group resolves. |
+| `group.concurrent(io, func, args)` | Add a concurrent task to the group. Fails with `error.ConcurrencyUnavailable` if backend cannot oversubscribe. |
+| `group.await(io)` | Block until every task in the group resolves. |
 | `io.async(func, args)` | Decouple call from return; may or may not run concurrently. |
 
-**Implication for `zcc`:** Use `io.concurrent` for per-TU compilation. Each TU gets its own `ArenaAllocator`. The main thread calls `group.awaitAll(io)` and then proceeds to the link step.
+**Implication for `zcc`:** Use `group.concurrent` for per-TU compilation. Each TU gets its own `ArenaAllocator`. The main thread calls `group.await(io)` and then proceeds to the link step.
 
 ## 3. Groups (`std.Io.Group`)
 
-`std.Io.Group` synchronizes batches of futures. It replaces the old `std.Thread.WaitGroup` pattern in 0.16.
+`std.Io.Group` is the canonical wait-group API in Zig 0.16. It synchronizes batches of concurrent tasks.
 
 ### Pattern: phased pipeline
 
 ```zig
 fn pipeline(gpa: std.mem.Allocator, io: std.Io, tus: []const TranslationUnit) !void {
     // given translation units
-    var lex_group = std.Io.Group.init(gpa);
-    defer lex_group.deinit();
-    var parse_group = std.Io.Group.init(gpa);
-    defer parse_group.deinit();
+    var lex_group: std.Io.Group = .init;
+    var parse_group: std.Io.Group = .init;
 
     // when we lex all TUs in parallel
     for (tus) |tu| {
-        const future = try io.concurrent(lexTu, .{ gpa, tu });
-        lex_group.add(future);
+        try lex_group.concurrent(io, lexTu, .{ gpa, tu });
     }
-    try lex_group.awaitAll(io);
+    try lex_group.await(io);
 
     // then we parse all TUs in parallel
     for (tus) |tu| {
-        const future = try io.concurrent(parseTu, .{ gpa, tu });
-        parse_group.add(future);
+        try parse_group.concurrent(io, parseTu, .{ gpa, tu });
     }
-    try parse_group.awaitAll(io);
+    try parse_group.await(io);
 }
 ```
 
@@ -233,18 +226,16 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     // when we initialize the I/O backend
-    var threaded = try std.Io.Threaded.init(allocator, .{});
+    var threaded = std.Io.Threaded.init(allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
 
     // compile each TU in parallel
-    var group = std.Io.Group.init(allocator);
-    defer group.deinit();
+    var group: std.Io.Group = .init;
     for (args[1..]) |tu_path| {
-        const future = try io.concurrent(compileTuPipeline, .{ allocator, io, tu_path });
-        group.add(future);
+        try group.concurrent(io, compileTuPipeline, .{ allocator, io, tu_path });
     }
-    try group.awaitAll(io);
+    try group.await(io);
 
     // then link all object files
     try linkObjects(allocator, io, &obj_files);


### PR DESCRIPTION
## Summary

{[writing-engineer]} Phase 2 foundational documentation: three documents that establish the build contract, concurrency patterns, and C11-to-Zig mapping for the `zcc` compiler.

## Changes

- `docs/playbooks/zig-build-discipline.md` (225 lines)
  - `build.zig` target contract: `test`, `smoke`, `fmt`, `lint`, `clean`
  - CI matrix for `.github/workflows/phase2-zig.yml`
  - Skeleton `build.zig` with all required steps
  - Directory layout for `phase2/`
  - Test discipline: unit (co-located), integration, smoke
  - Common failure modes table
  - `reviewer-quality` checklist

- `docs/research/zig-async-patterns.md` (261 lines)
  - `std.Io` interface (replaces old `async`/`await`)
  - `std.Thread.Pool` with `spawnWg` / `WaitGroup`
  - `std.atomic.Value` for lock-free counters and versioning
  - `std.heap.ArenaAllocator` per-TU strategy
  - `std.process.Child` for assembler/linker invocation
  - Full driver sketch combining all patterns
  - Deprecated API warnings table

- `docs/research/c11-zig-mapping.md` (340 lines)
  - Complete type system mapping (scalars, derived, qualifiers, attributes)
  - Memory/storage duration mapping (auto, static, thread, dynamic, VLAs)
  - Control flow, functions, concurrency primitives
  - Preprocessor/`_Generic` to `comptime` mapping
  - Standard library mapping (stdio, string, stdlib, math)
  - ABI and calling conventions
  - Edge cases: VLAs, union punning, flexible arrays, signed overflow, pointer arithmetic, integer promotion

## Test Plan

- [x] All three docs render correctly in GitHub Markdown preview
- [x] No broken internal links (checked via `rg '\]\(' docs/`)
- [x] Code blocks have language tags
- [x] given/when/then style in all test snippets
- [x] No Arrange-Act-Assert comments
- [x] English only
- [x] No external Zig dependencies referenced (stdlib only)
- [x] Style matches `docs/playbooks/c-makefile-discipline.md` (PR #13)

## Related Issues

Closes sub-issue tracking for Phase 2 documentation (part of milestone phase-2-zig-zcc).

## Reviewer Notes

This is a documentation-only PR. No code changes. No CI workflow changes. The docs are ready for the 4-gate review cycle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three Phase 2 docs that define the `build.zig` target contract, Zig 0.16 async/concurrency patterns, and a C11→Zig 0.16 mapping for `zcc`. Docs-only; standardizes how we build, parallelize, and interpret C11 semantics in Phase 2.

- **Bug Fixes**
  - Async patterns: use `std.Io.Threaded`/`std.Io.Group` with `group.concurrent` + `group.await`; fixed `Threaded.init` and `.io()` usage; clarified pipe-reader (`File.reader`) and full-stream slurp via `allocRemaining(.unlimited)`; removed WaitGroup references.
  - Process examples: `std.process.run` is synchronous; non-blocking via `spawn` + `child.wait(io)`; free `result.stdout/stderr`; removed the invalid pipe sample and pointed to stdlib for exact 0.16 APIs.
  - Build discipline: consistent `std.Build` usage (`b.createModule` + `b.addExecutable`/`b.addTest(.{ .root_module = ... })`); fixed the integration test example; `lint` covers `src/` and `tests/`; `clean` is docker-only subset; CI docker runs `clean test smoke`; smoke contract is wave-based (Wave 0→10); paths set to `phase2/zcc/`.
  - C11 mapping/backends: VLA example returns `!void`; use `@memcpy`/`std.mem.copyForwards`; `long double` is target-specific; no `goto`; `_Static_assert` → `comptime { assert(E); }`; evented backend limited to io_uring (Linux) and GCD (macOS); `mtx_init`/`cnd_init` map to `std.Thread.Mutex{}` / `std.Thread.Condition{}`; Docker command: `IMAGE=gcc:14 bash scripts/run-in-docker-phase2.sh zcc clean test smoke`.

<sup>Written for commit 07a733ff9ff181af4748bdf24d4ee6bd7940d12d. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/c11-compiler-zig-omo/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

