### PR TITLE
{[zig-engineer]} phase-2/zcc: Wave 0 scaffold

### DIFF
--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -46,10 +46,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.16.0
+      - name: Install Zig 0.16.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${RUNNER_OS}" in
+            Linux) zig_os="linux" ;;
+            macOS) zig_os="macos" ;;
+            *) echo "unsupported runner OS: ${RUNNER_OS}" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64|amd64) zig_arch="x86_64" ;;
+            aarch64|arm64) zig_arch="aarch64" ;;
+            *) echo "unsupported runner arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          zig_dir="zig-${zig_arch}-${zig_os}-0.16.0"
+          curl -fsSL "https://ziglang.org/download/0.16.0/${zig_dir}.tar.xz" -o /tmp/zig.tar.xz
+          mkdir -p "${RUNNER_TEMP}/zig"
+          tar -xJf /tmp/zig.tar.xz -C "${RUNNER_TEMP}/zig" --strip-components=1
+          echo "${RUNNER_TEMP}/zig" >> "$GITHUB_PATH"
+          "${RUNNER_TEMP}/zig/zig" version
       - name: zig fmt --check
         working-directory: phase2/zcc
         run: zig build fmt

--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -60,8 +60,21 @@ jobs:
             aarch64|arm64) zig_arch="aarch64" ;;
             *) echo "unsupported runner arch: $(uname -m)" >&2; exit 1 ;;
           esac
+          case "${zig_arch}-${zig_os}" in
+            aarch64-macos) zig_sha256="b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489" ;;
+            x86_64-macos) zig_sha256="0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7" ;;
+            x86_64-linux) zig_sha256="70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00" ;;
+            aarch64-linux) zig_sha256="ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17" ;;
+            *) echo "missing checksum for ${zig_arch}-${zig_os}" >&2; exit 1 ;;
+          esac
           zig_dir="zig-${zig_arch}-${zig_os}-0.16.0"
           curl -fsSL "https://ziglang.org/download/0.16.0/${zig_dir}.tar.xz" -o /tmp/zig.tar.xz
+          printf '%s  %s\n' "${zig_sha256}" /tmp/zig.tar.xz > /tmp/zig.tar.xz.sha256
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c /tmp/zig.tar.xz.sha256
+          else
+            shasum -a 256 -c /tmp/zig.tar.xz.sha256
+          fi
           mkdir -p "${RUNNER_TEMP}/zig"
           tar -xJf /tmp/zig.tar.xz -C "${RUNNER_TEMP}/zig" --strip-components=1
           echo "${RUNNER_TEMP}/zig" >> "$GITHUB_PATH"

--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -21,21 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_zig: ${{ steps.detect.outputs.has_zig }}
+      should_run_phase2: ${{ steps.detect.outputs.should_run_phase2 }}
     steps:
       - uses: actions/checkout@v4
       - id: detect
         run: |
-          if [ -f phase2/build.zig ]; then
+          if [ -f phase2/zcc/build.zig ]; then
             echo "has_zig=true" >> "$GITHUB_OUTPUT"
+            echo "should_run_phase2=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_zig=false" >> "$GITHUB_OUTPUT"
-            echo "phase2/build.zig not present yet — phase-2 build/test skipped."
+            echo "should_run_phase2=false" >> "$GITHUB_OUTPUT"
+            echo "phase2/zcc/build.zig not present yet — phase-2 build/test skipped."
           fi
 
   build-and-test:
     name: zcc build & test (${{ matrix.os }})
     needs: guard
-    if: needs.guard.outputs.has_zig == 'true'
+    if: needs.guard.outputs.should_run_phase2 == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -48,11 +51,27 @@ jobs:
         with:
           version: 0.16.0
       - name: zig fmt --check
-        working-directory: phase2
-        run: zig fmt --check src tests build.zig
+        working-directory: phase2/zcc
+        run: zig build fmt
       - name: zig build
-        working-directory: phase2
-        run: zig build -Drelease-safe
+        working-directory: phase2/zcc
+        run: zig build
       - name: zig build test
-        working-directory: phase2
+        working-directory: phase2/zcc
         run: zig build test --summary all
+      - name: zig build smoke
+        working-directory: phase2/zcc
+        run: zig build smoke --summary all
+      - name: zig build lint
+        working-directory: phase2/zcc
+        run: zig build lint --summary all
+
+  docker-gcc-14:
+    name: phase2-zig / docker / gcc-14 / zcc
+    needs: guard
+    if: needs.guard.outputs.should_run_phase2 == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: zcc in gcc:14 container
+        run: IMAGE=gcc:14 bash scripts/run-in-docker.sh phase2 zcc clean test smoke

--- a/.github/workflows/phase2-zig.yml
+++ b/.github/workflows/phase2-zig.yml
@@ -90,4 +90,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: zcc in gcc:14 container
-        run: IMAGE=gcc:14 bash scripts/run-in-docker.sh phase2 zcc clean test smoke
+        run: IMAGE=gcc:14 bash scripts/run-in-docker-phase2.sh zcc clean test smoke

--- a/phase2/zcc/README.md
+++ b/phase2/zcc/README.md
@@ -13,7 +13,7 @@ zig build test
 
 ```bash
 zig build run -- --help
-zig build run -- -E hello.c
+zig build run -- -E tests/smoke/hello.c
 ```
 
 Wave 0 implements the build system, CLI parsing, and a preprocessor-only token dump stub. Code generation is intentionally not implemented yet.

--- a/phase2/zcc/README.md
+++ b/phase2/zcc/README.md
@@ -1,0 +1,19 @@
+# zcc Wave 0 scaffold
+
+`zcc` is the Phase 2 zero-dependency Zig 0.16 C11 compiler.
+
+## Build
+
+```bash
+zig build
+zig build test
+```
+
+## Run
+
+```bash
+zig build run -- --help
+zig build run -- -E hello.c
+```
+
+Wave 0 implements the build system, CLI parsing, and a preprocessor-only token dump stub. Code generation is intentionally not implemented yet.

--- a/phase2/zcc/build.zig
+++ b/phase2/zcc/build.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "zcc",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run zcc");
+    run_step.dependOn(&run_cmd.step);
+
+    const smoke_cmd = b.addRunArtifact(exe);
+    smoke_cmd.addArgs(&.{ "-E", "tests/smoke/hello.c" });
+
+    const smoke_step = b.step("smoke", "Run zcc smoke tests");
+    smoke_step.dependOn(&smoke_cmd.step);
+
+    const fmt = b.addFmt(.{
+        .paths = &.{ "src", "tests", "build.zig" },
+        .check = true,
+    });
+
+    const fmt_step = b.step("fmt", "Check Zig formatting");
+    fmt_step.dependOn(&fmt.step);
+
+    const lint_cmd = b.addSystemCommand(&.{
+        b.graph.zig_exe,
+        "build-exe",
+        "-fno-emit-bin",
+        "src/main.zig",
+    });
+
+    const lint_step = b.step("lint", "Check zcc compilation without emitting binary");
+    lint_step.dependOn(&lint_cmd.step);
+
+    const cli_module = b.createModule(.{
+        .root_source_file = b.path("src/cli.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const cli_test_module = b.createModule(.{
+        .root_source_file = b.path("src/cli_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    cli_test_module.addImport("cli", cli_module);
+
+    const cli_tests = b.addTest(.{ .root_module = cli_test_module });
+    const run_cli_tests = b.addRunArtifact(cli_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_cli_tests.step);
+}

--- a/phase2/zcc/src/cli.zig
+++ b/phase2/zcc/src/cli.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+
+pub const Mode = enum {
+    compile,
+    preprocess,
+};
+
+pub const Optimization = enum {
+    O0,
+    O2,
+};
+
+pub const ParseError = error{
+    MissingOutputPath,
+    EmptySanitizerList,
+    UnknownOption,
+};
+
+pub const CliConfig = struct {
+    help: bool = false,
+    mode: Mode = .compile,
+    output: ?[]const u8 = null,
+    compile_only: bool = false,
+    optimization: Optimization = .O0,
+    debug_info: bool = false,
+    sanitizers: []const []const u8 = &.{},
+    inputs: []const []const u8 = &.{},
+
+    pub fn deinit(self: *CliConfig, allocator: std.mem.Allocator) void {
+        allocator.free(self.sanitizers);
+        allocator.free(self.inputs);
+        self.* = .{};
+    }
+};
+
+pub const usage =
+    \\Usage: zcc [options] file...
+    \\
+    \\Options:
+    \\  --help              Print this help and exit
+    \\  -E                  Run preprocessor-only token dump
+    \\  -c                  Compile only, do not link
+    \\  -o <path>           Write output to path
+    \\  -O0 | -O2           Select optimization level
+    \\  -g                  Emit debug information
+    \\  -fsanitize=<list>   Enable sanitizer list
+    \\
+;
+
+pub fn parse(allocator: std.mem.Allocator, args: []const []const u8) (std.mem.Allocator.Error || ParseError)!CliConfig {
+    var config: CliConfig = .{};
+    errdefer config.deinit(allocator);
+
+    var sanitizers: std.ArrayList([]const u8) = .empty;
+    defer sanitizers.deinit(allocator);
+
+    var inputs: std.ArrayList([]const u8) = .empty;
+    defer inputs.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--help")) {
+            config.help = true;
+        } else if (std.mem.eql(u8, arg, "-E")) {
+            config.mode = .preprocess;
+        } else if (std.mem.eql(u8, arg, "-c")) {
+            config.compile_only = true;
+        } else if (std.mem.eql(u8, arg, "-o")) {
+            i += 1;
+            if (i == args.len) {
+                return error.MissingOutputPath;
+            }
+            config.output = args[i];
+        } else if (std.mem.eql(u8, arg, "-O0")) {
+            config.optimization = .O0;
+        } else if (std.mem.eql(u8, arg, "-O2")) {
+            config.optimization = .O2;
+        } else if (std.mem.eql(u8, arg, "-g")) {
+            config.debug_info = true;
+        } else if (std.mem.startsWith(u8, arg, "-fsanitize=")) {
+            const value = arg["-fsanitize=".len..];
+            if (value.len == 0) {
+                return error.EmptySanitizerList;
+            }
+            try sanitizers.append(allocator, value);
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            return error.UnknownOption;
+        } else {
+            try inputs.append(allocator, arg);
+        }
+    }
+
+    config.sanitizers = try sanitizers.toOwnedSlice(allocator);
+    config.inputs = try inputs.toOwnedSlice(allocator);
+    return config;
+}
+
+pub fn errorMessage(err: ParseError) []const u8 {
+    return switch (err) {
+        error.MissingOutputPath => "expected path after -o",
+        error.EmptySanitizerList => "expected sanitizer list after -fsanitize=",
+        error.UnknownOption => "unknown option",
+    };
+}

--- a/phase2/zcc/src/cli.zig
+++ b/phase2/zcc/src/cli.zig
@@ -37,7 +37,7 @@ pub const usage =
     \\Usage: zcc [options] file...
     \\
     \\Options:
-    \\  --help              Print this help and exit
+    \\  --help, -h          Print this help and exit
     \\  -E                  Run preprocessor-only token dump
     \\  -c                  Compile only, do not link
     \\  -o <path>           Write output to path
@@ -51,6 +51,13 @@ pub fn parse(allocator: std.mem.Allocator, args: []const []const u8) (std.mem.Al
     var config: CliConfig = .{};
     errdefer config.deinit(allocator);
 
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            config.help = true;
+            return config;
+        }
+    }
+
     var sanitizers: std.ArrayList([]const u8) = .empty;
     defer sanitizers.deinit(allocator);
 
@@ -60,9 +67,7 @@ pub fn parse(allocator: std.mem.Allocator, args: []const []const u8) (std.mem.Al
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
-        if (std.mem.eql(u8, arg, "--help")) {
-            config.help = true;
-        } else if (std.mem.eql(u8, arg, "-E")) {
+        if (std.mem.eql(u8, arg, "-E")) {
             config.mode = .preprocess;
         } else if (std.mem.eql(u8, arg, "-c")) {
             config.compile_only = true;

--- a/phase2/zcc/src/cli_test.zig
+++ b/phase2/zcc/src/cli_test.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+
+const cli = @import("cli");
+
+test "parse help exits before requiring inputs" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{"--help"};
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expect(config.help);
+    try std.testing.expectEqual(@as(usize, 0), config.inputs.len);
+}
+
+test "parse compile flags and inputs" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{ "-c", "-O2", "-g", "-o", "hello.o", "hello.c" };
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expect(!config.help);
+    try std.testing.expect(config.compile_only);
+    try std.testing.expectEqual(cli.Optimization.O2, config.optimization);
+    try std.testing.expect(config.debug_info);
+    try std.testing.expectEqualStrings("hello.o", config.output.?);
+    try std.testing.expectEqual(@as(usize, 1), config.inputs.len);
+    try std.testing.expectEqualStrings("hello.c", config.inputs[0]);
+}
+
+test "parse preprocessor and sanitizer flags" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{ "-E", "-fsanitize=undefined,address", "foo.c" };
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expectEqual(cli.Mode.preprocess, config.mode);
+    try std.testing.expectEqual(@as(usize, 1), config.sanitizers.len);
+    try std.testing.expectEqualStrings("undefined,address", config.sanitizers[0]);
+    try std.testing.expectEqualStrings("foo.c", config.inputs[0]);
+}
+
+test "parse rejects missing output path" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{"-o"};
+
+    // when
+    const result = cli.parse(allocator, args);
+
+    // then
+    try std.testing.expectError(error.MissingOutputPath, result);
+}
+
+test "parse rejects unknown options" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{"-Wall"};
+
+    // when
+    const result = cli.parse(allocator, args);
+
+    // then
+    try std.testing.expectError(error.UnknownOption, result);
+}

--- a/phase2/zcc/src/cli_test.zig
+++ b/phase2/zcc/src/cli_test.zig
@@ -79,3 +79,51 @@ test "parse rejects unknown options" {
     // then
     try std.testing.expectError(error.UnknownOption, result);
 }
+
+test "test_cli_handles_multiple_input_files" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{ "foo.c", "bar.c", "baz.c" };
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expect(!config.help);
+    try std.testing.expectEqual(@as(usize, 3), config.inputs.len);
+    try std.testing.expectEqualStrings("foo.c", config.inputs[0]);
+    try std.testing.expectEqualStrings("bar.c", config.inputs[1]);
+    try std.testing.expectEqualStrings("baz.c", config.inputs[2]);
+}
+
+test "test_cli_help_short_circuits_unknown_options" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{ "zcc", "--help", "-Wall" };
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expect(config.help);
+    try std.testing.expectEqual(@as(usize, 0), config.inputs.len);
+}
+
+test "test_cli_help_short_circuits_when_followed_by_unknown_flag" {
+    const allocator = std.testing.allocator;
+
+    // given
+    const args = &[_][]const u8{ "zcc", "--unknown-thing", "--help" };
+
+    // when
+    var config = try cli.parse(allocator, args);
+    defer config.deinit(allocator);
+
+    // then
+    try std.testing.expect(config.help);
+    try std.testing.expectEqual(@as(usize, 0), config.inputs.len);
+}

--- a/phase2/zcc/src/main.zig
+++ b/phase2/zcc/src/main.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+
+const cli = @import("cli.zig");
+
+pub fn main(init: std.process.Init) !u8 {
+    const allocator = init.gpa;
+    const argv = try init.minimal.args.toSlice(init.arena.allocator());
+
+    var config = cli.parse(allocator, argv[1..]) catch |err| switch (err) {
+        error.MissingOutputPath, error.EmptySanitizerList, error.UnknownOption => {
+            var stderr_buffer: [1024]u8 = undefined;
+            var stderr_file_writer: std.Io.File.Writer = .init(.stderr(), init.io, &stderr_buffer);
+            const stderr = &stderr_file_writer.interface;
+            defer stderr.flush() catch {};
+
+            const message = switch (err) {
+                error.MissingOutputPath => "expected path after -o",
+                error.EmptySanitizerList => "expected sanitizer list after -fsanitize=",
+                error.UnknownOption => "unknown option",
+                else => unreachable,
+            };
+            try stderr.print("zcc: error: {s}\n\n{s}", .{ message, cli.usage });
+            return 1;
+        },
+        else => |alloc_err| return alloc_err,
+    };
+    defer config.deinit(allocator);
+
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_file_writer: std.Io.File.Writer = .init(.stdout(), init.io, &stdout_buffer);
+    const stdout = &stdout_file_writer.interface;
+    defer stdout.flush() catch {};
+
+    var stderr_buffer: [4096]u8 = undefined;
+    var stderr_file_writer: std.Io.File.Writer = .init(.stderr(), init.io, &stderr_buffer);
+    const stderr = &stderr_file_writer.interface;
+    defer stderr.flush() catch {};
+
+    if (config.help) {
+        try stdout.writeAll(cli.usage);
+        return 0;
+    }
+
+    if (config.inputs.len == 0) {
+        try stderr.print("zcc: error: no input files\n\n{s}", .{cli.usage});
+        return 1;
+    }
+
+    switch (config.mode) {
+        .compile => {
+            try stderr.writeAll("zcc: compile pipeline is not implemented yet\n");
+            return 1;
+        },
+        .preprocess => try runPreprocessOnly(allocator, config.inputs, init.io, stdout),
+    }
+
+    return 0;
+}
+
+fn runPreprocessOnly(allocator: std.mem.Allocator, inputs: []const []const u8, io: std.Io, writer: *std.Io.Writer) !void {
+    for (inputs) |path| {
+        const source = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(16 * 1024 * 1024));
+        defer allocator.free(source);
+
+        try dumpTokens(path, source, writer);
+    }
+}
+
+fn dumpTokens(path: []const u8, source: []const u8, writer: *std.Io.Writer) !void {
+    var i: usize = 0;
+    while (i < source.len) {
+        const byte = source[i];
+        if (std.ascii.isWhitespace(byte)) {
+            i += 1;
+            continue;
+        }
+
+        const start = i;
+        if (isIdentStart(byte)) {
+            i += 1;
+            while (i < source.len and isIdentContinue(source[i])) : (i += 1) {}
+            try writer.print("{s}: identifier {s}\n", .{ path, source[start..i] });
+        } else if (std.ascii.isDigit(byte)) {
+            i += 1;
+            while (i < source.len and std.ascii.isDigit(source[i])) : (i += 1) {}
+            try writer.print("{s}: number {s}\n", .{ path, source[start..i] });
+        } else {
+            i += 1;
+            try writer.print("{s}: punctuator {s}\n", .{ path, source[start..i] });
+        }
+    }
+}
+
+fn isIdentStart(byte: u8) bool {
+    return std.ascii.isAlphabetic(byte) or byte == '_';
+}
+
+fn isIdentContinue(byte: u8) bool {
+    return isIdentStart(byte) or std.ascii.isDigit(byte);
+}

--- a/phase2/zcc/tests/smoke/hello.c
+++ b/phase2/zcc/tests/smoke/hello.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/scripts/run-in-docker-phase2.sh
+++ b/scripts/run-in-docker-phase2.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/run-in-docker-phase2.sh
+#
+# Reproduce the Phase-2 zcc Docker CI cell locally.
+#
+# Usage:
+#   scripts/run-in-docker-phase2.sh zcc [target...] [IMAGE=gcc:14]
+#
+# Examples:
+#   scripts/run-in-docker-phase2.sh zcc clean test smoke
+#   IMAGE=gcc:14 scripts/run-in-docker-phase2.sh zcc clean test smoke
+#
+# Requires Docker (use OrbStack on macOS: `orb start`).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+IMAGE="${IMAGE:-gcc:14}"
+SUB="${1:?usage: $0 <zcc> [targets...] [IMAGE=gcc:14]}"
+shift || true
+
+if [ ! -d "${ROOT}/phase2/${SUB}" ]; then
+  echo "error: phase2/${SUB} does not exist under ${ROOT}" >&2
+  exit 2
+fi
+if [ ! -f "${ROOT}/phase2/${SUB}/build.zig" ]; then
+  echo "error: phase2/${SUB}/build.zig not found (subproject not authored yet)" >&2
+  exit 2
+fi
+
+TARGETS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --)      : ;;
+    IMAGE=*) IMAGE="${1#IMAGE=}" ;;
+    *=*)     echo "error: phase2 docker runner does not accept make vars: $1" >&2; exit 2 ;;
+    *)       TARGETS+=("$1") ;;
+  esac
+  shift
+done
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  TARGETS=(test smoke)
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required. on macOS: 'orb start' to launch OrbStack." >&2
+  exit 3
+fi
+
+echo "==> image=${IMAGE}  subproject=phase2/${SUB}  targets=[${TARGETS[*]}]"
+
+cmd='set -euxo pipefail; export PATH="/opt/zig:$PATH"; if ! command -v zig >/dev/null 2>&1; then apt-get update; apt-get install -y --no-install-recommends ca-certificates curl xz-utils; arch="$(uname -m)"; case "$arch" in x86_64|amd64) zig_arch="x86_64" ;; aarch64|arm64) zig_arch="aarch64" ;; *) echo "unsupported arch: $arch" >&2; exit 4 ;; esac; curl -fsSL "https://ziglang.org/download/0.16.0/zig-${zig_arch}-linux-0.16.0.tar.xz" -o /tmp/zig.tar.xz; mkdir -p /opt/zig; tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; fi; zig version;'
+for target in "${TARGETS[@]}"; do
+  case "${target}" in
+    clean) cmd+=' rm -rf .zig-cache zig-out;' ;;
+    all|build) cmd+=' zig build;' ;;
+    test|smoke|fmt|lint) cmd+=" zig build $(printf '%q' "$target");" ;;
+    *) echo "error: unsupported phase2 target: ${target}" >&2; exit 2 ;;
+  esac
+done
+
+docker run --rm \
+  -v "${ROOT}:/work" \
+  -w "/work/phase2/${SUB}" \
+  "${IMAGE}" \
+  bash -c "$cmd"

--- a/scripts/run-in-docker-phase2.sh
+++ b/scripts/run-in-docker-phase2.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 IMAGE="${IMAGE:-gcc:14}"
+ZIG_VERSION="0.16.0"
 SUB="${1:?usage: $0 <zcc> [targets...] [IMAGE=gcc:14]}"
 shift || true
 
@@ -51,7 +52,7 @@ fi
 
 echo "==> image=${IMAGE}  subproject=phase2/${SUB}  targets=[${TARGETS[*]}]"
 
-cmd='set -euxo pipefail; export PATH="/opt/zig:$PATH"; if ! command -v zig >/dev/null 2>&1; then apt-get update; apt-get install -y --no-install-recommends ca-certificates curl xz-utils; arch="$(uname -m)"; case "$arch" in x86_64|amd64) zig_arch="x86_64" ;; aarch64|arm64) zig_arch="aarch64" ;; *) echo "unsupported arch: $arch" >&2; exit 4 ;; esac; curl -fsSL "https://ziglang.org/download/0.16.0/zig-${zig_arch}-linux-0.16.0.tar.xz" -o /tmp/zig.tar.xz; mkdir -p /opt/zig; tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; fi; zig version;'
+cmd='set -euxo pipefail; ZIG_VERSION="0.16.0"; export PATH="/opt/zig:$PATH"; install_zig() { apt-get update; apt-get install -y --no-install-recommends ca-certificates curl xz-utils; arch="$(uname -m)"; case "$arch" in x86_64|amd64) zig_arch="x86_64" ;; aarch64|arm64) zig_arch="aarch64" ;; *) echo "unsupported arch: $arch" >&2; exit 4 ;; esac; rm -rf /opt/zig; curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz; mkdir -p /opt/zig; tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; }; if command -v zig >/dev/null 2>&1; then installed_version="$(zig version 2>/dev/null || echo missing)"; if [ "$installed_version" != "$ZIG_VERSION" ]; then install_zig; fi; else install_zig; fi; zig version;'
 for target in "${TARGETS[@]}"; do
   case "${target}" in
     clean) cmd+=' rm -rf .zig-cache zig-out;' ;;

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 # scripts/run-in-docker.sh
 #
-# Reproduce the Phase-1 gcc-in-docker CI matrix locally. Same image,
-# same volume layout, same make invocation as .github/workflows/phase1-c.yml.
+# Reproduce gcc-in-docker CI matrices locally. Same image and volume layout
+# as GitHub Actions, with phase-aware build commands.
 #
 # Usage:
-#   scripts/run-in-docker.sh <subproject> [target...] [-- IMAGE=gcc:14] [IO=epoll|io_uring]
+#   scripts/run-in-docker.sh [phase1] <subproject> [target...] [-- IMAGE=gcc:14] [IO=epoll|io_uring]
+#   scripts/run-in-docker.sh phase2 <subproject> [target...] [-- IMAGE=gcc:14]
 #
 # Examples:
 #   scripts/run-in-docker.sh c11-ref            # default: print-platform + all + test
 #   scripts/run-in-docker.sh http2 all test smoke IO=io_uring
 #   scripts/run-in-docker.sh doom all smoke -- IMAGE=gcc:13
+#   scripts/run-in-docker.sh phase2 zcc clean test smoke IMAGE=gcc:14
 #
 # Requires Docker (use OrbStack on macOS: `orb start`).
 
@@ -19,15 +21,28 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 IMAGE="${IMAGE:-gcc:14}"
-SUB="${1:?usage: $0 <c11-ref|http2|doom> [targets...] [VAR=value...]}"
+PHASE="phase1"
+SUB="${1:?usage: $0 [phase1] <c11-ref|http2|doom> [targets...] [VAR=value...] OR $0 phase2 <zcc> [targets...]}"
 shift || true
 
-if [ ! -d "${ROOT}/phase1/${SUB}" ]; then
-  echo "error: phase1/${SUB} does not exist under ${ROOT}" >&2
+case "${SUB}" in
+  phase1|phase2)
+    PHASE="${SUB}"
+    SUB="${1:?usage: $0 ${PHASE} <subproject> [targets...] [VAR=value...]}"
+    shift || true
+    ;;
+esac
+
+if [ ! -d "${ROOT}/${PHASE}/${SUB}" ]; then
+  echo "error: ${PHASE}/${SUB} does not exist under ${ROOT}" >&2
   exit 2
 fi
-if [ ! -f "${ROOT}/phase1/${SUB}/Makefile" ]; then
-  echo "error: phase1/${SUB}/Makefile not found (subproject not authored yet)" >&2
+if [ "${PHASE}" = "phase1" ] && [ ! -f "${ROOT}/${PHASE}/${SUB}/Makefile" ]; then
+  echo "error: ${PHASE}/${SUB}/Makefile not found (subproject not authored yet)" >&2
+  exit 2
+fi
+if [ "${PHASE}" = "phase2" ] && [ ! -f "${ROOT}/${PHASE}/${SUB}/build.zig" ]; then
+  echo "error: ${PHASE}/${SUB}/build.zig not found (subproject not authored yet)" >&2
   exit 2
 fi
 
@@ -44,7 +59,11 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "${#TARGETS[@]}" -eq 0 ]; then
-  TARGETS=(print-platform all test)
+  if [ "${PHASE}" = "phase1" ]; then
+    TARGETS=(print-platform all test)
+  else
+    TARGETS=(test smoke)
+  fi
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
@@ -52,22 +71,34 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 3
 fi
 
-echo "==> image=${IMAGE}  subproject=phase1/${SUB}  vars=[${MAKE_VARS[*]:-}]  targets=[${TARGETS[*]}]"
+echo "==> image=${IMAGE}  subproject=${PHASE}/${SUB}  vars=[${MAKE_VARS[*]:-}]  targets=[${TARGETS[*]}]"
 
 # Build a shell-safe command line so whitespace in make variables (e.g.
 # CFLAGS='-O2 -g -fsanitize=address') survives the trip through docker.
-cmd="set -euxo pipefail; exec make"
-if [ "${#MAKE_VARS[@]}" -gt 0 ]; then
-  for v in "${MAKE_VARS[@]}"; do
-    cmd+=" $(printf '%q' "$v")"
+if [ "${PHASE}" = "phase1" ]; then
+  cmd="set -euxo pipefail; exec make"
+  if [ "${#MAKE_VARS[@]}" -gt 0 ]; then
+    for v in "${MAKE_VARS[@]}"; do
+      cmd+=" $(printf '%q' "$v")"
+    done
+  fi
+  for t in "${TARGETS[@]}"; do
+    cmd+=" $(printf '%q' "$t")"
+  done
+else
+  cmd='set -euxo pipefail; export PATH="/opt/zig:$PATH"; if ! command -v zig >/dev/null 2>&1; then apt-get update; apt-get install -y --no-install-recommends ca-certificates curl xz-utils; arch="$(uname -m)"; case "$arch" in x86_64|amd64) zig_arch="x86_64" ;; aarch64|arm64) zig_arch="aarch64" ;; *) echo "unsupported arch: $arch" >&2; exit 4 ;; esac; curl -fsSL "https://ziglang.org/download/0.16.0/zig-${zig_arch}-linux-0.16.0.tar.xz" -o /tmp/zig.tar.xz; mkdir -p /opt/zig; tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; fi; zig version;'
+  for t in "${TARGETS[@]}"; do
+    case "${t}" in
+      clean) cmd+=' rm -rf .zig-cache zig-out;' ;;
+      all|build) cmd+=' zig build;' ;;
+      test|smoke|fmt|lint) cmd+=" zig build $(printf '%q' "$t");" ;;
+      *) echo "error: unsupported phase2 target: ${t}" >&2; exit 2 ;;
+    esac
   done
 fi
-for t in "${TARGETS[@]}"; do
-  cmd+=" $(printf '%q' "$t")"
-done
 
 docker run --rm \
   -v "${ROOT}:/work" \
-  -w "/work/phase1/${SUB}" \
+  -w "/work/${PHASE}/${SUB}" \
   "${IMAGE}" \
   bash -c "$cmd"

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 # scripts/run-in-docker.sh
 #
-# Reproduce gcc-in-docker CI matrices locally. Same image and volume layout
-# as GitHub Actions, with phase-aware build commands.
+# Reproduce the Phase-1 gcc-in-docker CI matrix locally. Same image,
+# same volume layout, same make invocation as .github/workflows/phase1-c.yml.
 #
 # Usage:
-#   scripts/run-in-docker.sh [phase1] <subproject> [target...] [-- IMAGE=gcc:14] [IO=epoll|io_uring]
-#   scripts/run-in-docker.sh phase2 <subproject> [target...] [-- IMAGE=gcc:14]
+#   scripts/run-in-docker.sh <subproject> [target...] [-- IMAGE=gcc:14] [IO=epoll|io_uring]
 #
 # Examples:
 #   scripts/run-in-docker.sh c11-ref            # default: print-platform + all + test
 #   scripts/run-in-docker.sh http2 all test smoke IO=io_uring
 #   scripts/run-in-docker.sh doom all smoke -- IMAGE=gcc:13
-#   scripts/run-in-docker.sh phase2 zcc clean test smoke IMAGE=gcc:14
 #
 # Requires Docker (use OrbStack on macOS: `orb start`).
 
@@ -21,28 +19,15 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 IMAGE="${IMAGE:-gcc:14}"
-PHASE="phase1"
-SUB="${1:?usage: $0 [phase1] <c11-ref|http2|doom> [targets...] [VAR=value...] OR $0 phase2 <zcc> [targets...]}"
+SUB="${1:?usage: $0 <c11-ref|http2|doom> [targets...] [VAR=value...]}"
 shift || true
 
-case "${SUB}" in
-  phase1|phase2)
-    PHASE="${SUB}"
-    SUB="${1:?usage: $0 ${PHASE} <subproject> [targets...] [VAR=value...]}"
-    shift || true
-    ;;
-esac
-
-if [ ! -d "${ROOT}/${PHASE}/${SUB}" ]; then
-  echo "error: ${PHASE}/${SUB} does not exist under ${ROOT}" >&2
+if [ ! -d "${ROOT}/phase1/${SUB}" ]; then
+  echo "error: phase1/${SUB} does not exist under ${ROOT}" >&2
   exit 2
 fi
-if [ "${PHASE}" = "phase1" ] && [ ! -f "${ROOT}/${PHASE}/${SUB}/Makefile" ]; then
-  echo "error: ${PHASE}/${SUB}/Makefile not found (subproject not authored yet)" >&2
-  exit 2
-fi
-if [ "${PHASE}" = "phase2" ] && [ ! -f "${ROOT}/${PHASE}/${SUB}/build.zig" ]; then
-  echo "error: ${PHASE}/${SUB}/build.zig not found (subproject not authored yet)" >&2
+if [ ! -f "${ROOT}/phase1/${SUB}/Makefile" ]; then
+  echo "error: phase1/${SUB}/Makefile not found (subproject not authored yet)" >&2
   exit 2
 fi
 
@@ -59,11 +44,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "${#TARGETS[@]}" -eq 0 ]; then
-  if [ "${PHASE}" = "phase1" ]; then
-    TARGETS=(print-platform all test)
-  else
-    TARGETS=(test smoke)
-  fi
+  TARGETS=(print-platform all test)
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
@@ -71,34 +52,22 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 3
 fi
 
-echo "==> image=${IMAGE}  subproject=${PHASE}/${SUB}  vars=[${MAKE_VARS[*]:-}]  targets=[${TARGETS[*]}]"
+echo "==> image=${IMAGE}  subproject=phase1/${SUB}  vars=[${MAKE_VARS[*]:-}]  targets=[${TARGETS[*]}]"
 
 # Build a shell-safe command line so whitespace in make variables (e.g.
 # CFLAGS='-O2 -g -fsanitize=address') survives the trip through docker.
-if [ "${PHASE}" = "phase1" ]; then
-  cmd="set -euxo pipefail; exec make"
-  if [ "${#MAKE_VARS[@]}" -gt 0 ]; then
-    for v in "${MAKE_VARS[@]}"; do
-      cmd+=" $(printf '%q' "$v")"
-    done
-  fi
-  for t in "${TARGETS[@]}"; do
-    cmd+=" $(printf '%q' "$t")"
-  done
-else
-  cmd='set -euxo pipefail; export PATH="/opt/zig:$PATH"; if ! command -v zig >/dev/null 2>&1; then apt-get update; apt-get install -y --no-install-recommends ca-certificates curl xz-utils; arch="$(uname -m)"; case "$arch" in x86_64|amd64) zig_arch="x86_64" ;; aarch64|arm64) zig_arch="aarch64" ;; *) echo "unsupported arch: $arch" >&2; exit 4 ;; esac; curl -fsSL "https://ziglang.org/download/0.16.0/zig-${zig_arch}-linux-0.16.0.tar.xz" -o /tmp/zig.tar.xz; mkdir -p /opt/zig; tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; fi; zig version;'
-  for t in "${TARGETS[@]}"; do
-    case "${t}" in
-      clean) cmd+=' rm -rf .zig-cache zig-out;' ;;
-      all|build) cmd+=' zig build;' ;;
-      test|smoke|fmt|lint) cmd+=" zig build $(printf '%q' "$t");" ;;
-      *) echo "error: unsupported phase2 target: ${t}" >&2; exit 2 ;;
-    esac
+cmd="set -euxo pipefail; exec make"
+if [ "${#MAKE_VARS[@]}" -gt 0 ]; then
+  for v in "${MAKE_VARS[@]}"; do
+    cmd+=" $(printf '%q' "$v")"
   done
 fi
+for t in "${TARGETS[@]}"; do
+  cmd+=" $(printf '%q' "$t")"
+done
 
 docker run --rm \
   -v "${ROOT}:/work" \
-  -w "/work/${PHASE}/${SUB}" \
+  -w "/work/phase1/${SUB}" \
   "${IMAGE}" \
   bash -c "$cmd"


### PR DESCRIPTION
## Summary
- Add zero-dependency Zig 0.16 `phase2/zcc` scaffold with `zcc` executable, CLI parser, driver entry, and preprocessor-only token dump stub.
- Add build contract targets: `zig build`, `test`, `smoke`, `fmt`, and `lint`.
- Update phase-2 CI for `phase2/zcc`, Zig 0.16 flags, gcc:14 Docker verification, and generalized docker runner support.

## Verification
- `zig build`
- `zig build test --summary all`
- `zig build smoke --summary all`
- `zig build fmt --summary all`
- `zig build lint --summary all`
- `./zig-out/bin/zcc --help`
- `IMAGE=gcc:14 bash scripts/run-in-docker.sh phase2 zcc clean test smoke`

{[zig-engineer]}

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/c11-compiler-zig-omo/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded `phase2/zcc`: a zero-dependency Zig 0.16 C11 compiler stub with a CLI and a preprocess-only token dump. CI now gates on `phase2/zcc/build.zig`, runs zcc-only checks, and verifies in a `gcc:14` Docker runner.

- **New Features**
  - `zcc` executable with CLI parsing: `--help`, `-E`, `-c`, `-o`, `-O0|-O2`, `-g`, `-fsanitize=<...>`.
  - Driver entry point; preprocess-only token dump for `-E` (codegen not implemented yet).
  - Unit tests for CLI; smoke test at `tests/smoke/hello.c`.
  - Build steps: `run`, `test`, `smoke`, `fmt` (check), `lint` (no-emit compile).
  - Phase-2 CI gates on `phase2/zcc/build.zig` (`should_run_phase2`), runs `fmt`, `build`, `test`, `smoke`, `lint`; adds `gcc:14` Docker job via `scripts/run-in-docker-phase2.sh zcc clean test smoke`.

- **Dependencies**
  - CI installs Zig 0.16 from official tarballs with SHA-256 verification (Linux/macOS); Docker runner installs Zig 0.16 on demand inside the container.

<sup>Written for commit 984e9aaab3cde0b4ce38dab238aa297503c81caf. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/c11-compiler-zig-omo/pull/35?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

